### PR TITLE
fix line order for fgd export

### DIFF
--- a/addons/qodot/src/resources/game-definitions/trenchbroom/trenchbroom_face_attrib_defaults.gd
+++ b/addons/qodot/src/resources/game-definitions/trenchbroom/trenchbroom_face_attrib_defaults.gd
@@ -1,5 +1,5 @@
-class_name TrenchBroomFaceAttribDefaults extends Resource
 @tool
+class_name TrenchBroomFaceAttribDefaults extends Resource
 
 @export var texture_name: String
 @export var offset: Vector2


### PR DESCRIPTION
Small fix, Line order of the `@tool` hint seems to be preventing the file from loading, this allows the export of fgd to work again for me.