### PR TITLE
Updated add_sibling() call to call on sibling and and with correct argument

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -206,7 +206,7 @@ func add_child_editor(parent, node, below = null) -> void:
 		prev_parent.remove_child(node)
 	
 	if below:
-		parent.add_sibling(below, node)
+		below.add_sibling(node)
 	else:
 		parent.add_child(node)
 	


### PR DESCRIPTION
I believe this closes #3

Based on referencing this function[ in the godot 3 version of qodot](
https://github.com/QodotPlugin/qodot-plugin/blob/8ad9933d0e670837c38bb5b20615b80299c7c5fd/addons/qodot/src/nodes/qodot_map.gd#L214) and the [Godot 4 docs for add_sibling](https://docs.godotengine.org/en/latest/classes/class_node.html#class-node-method-add-sibling), I believe calling this on "below" with the node to add below as the argument should produce the same behavior as in qodot 3.

When I tested it appeared to clear up the error in #3 but also introduced a new one pointing to a c# binding when building the map in the worldspawn example. It seems to point to https://github.com/QodotPlugin/Qodot/blob/7d09e19975d6550f5ebbea11b0a8a7bcc273b796/addons/qodot/src/core/Qodot.cs#L70 but I may be misinterpreting as I am not familiar with godot c# bindings. Here is the error (paths slightly redacted).

```
modules/mono/glue/runtime_interop.cpp:1223 - System.NullReferenceException: Object reference not set to an instance of an object.
     at Qodot.Qodot.SetWorldspawnLayers(Array worldspawnLayers) in /home/****/****/addons/qodot/src/core/Qodot.cs:line 70
     at Qodot.Qodot.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret) in /home/****/****/Godot.SourceGenerators/Godot.SourceGenerators.ScriptMethodsGenerator/Qodot.Qodot_ScriptMethods.generated.cs:line 74
     at Godot.Bridge.CSharpInstanceBridge.Call(IntPtr godotObjectGCHandle, godot_string_name* method, godot_variant** args, Int32 argCount, godot_variant_call_error* refCallError, godot_variant* ret) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs:line 24
```