### PR TITLE
added height maps to auto-pbr

### DIFF
--- a/addons/qodot/src/qodot_plugin.gd
+++ b/addons/qodot/src/qodot_plugin.gd
@@ -77,6 +77,8 @@ func setup_project_settings() -> void:
 	try_add_project_setting('qodot/textures/roughness_pattern', TYPE_STRING, QodotTextureLoader.PBR_SUFFIX_PATTERNS[QodotTextureLoader.PBRSuffix.ROUGHNESS])
 	try_add_project_setting('qodot/textures/emission_pattern', TYPE_STRING, QodotTextureLoader.PBR_SUFFIX_PATTERNS[QodotTextureLoader.PBRSuffix.EMISSION])
 	try_add_project_setting('qodot/textures/ao_pattern', TYPE_STRING, QodotTextureLoader.PBR_SUFFIX_PATTERNS[QodotTextureLoader.PBRSuffix.AO])
+	try_add_project_setting('qodot/textures/height_pattern', TYPE_STRING
+	QodotTextureLoader.PBR_SUFFIX_PATTERNS[QodotTextureLoader.PBRSuffix.HEIGHT])
 
 func try_add_project_setting(name: String, type: int, value, info: Dictionary = {}) -> void:
 	if not ProjectSettings.has_setting(name):

--- a/addons/qodot/src/util/qodot_texture_loader.gd
+++ b/addons/qodot/src/util/qodot_texture_loader.gd
@@ -7,7 +7,8 @@ enum PBRSuffix {
 	METALLIC,
 	ROUGHNESS,
 	EMISSION,
-	AO
+	AO,
+	HEIGHT,
 }
 
 # Suffix string / Godot enum / StandardMaterial3D property
@@ -17,6 +18,7 @@ const PBR_SUFFIX_NAMES := {
 	PBRSuffix.ROUGHNESS: 'roughness',
 	PBRSuffix.EMISSION: 'emission',
 	PBRSuffix.AO: 'ao',
+	PBRSuffix.HEIGHT: 'height',
 }
 
 const PBR_SUFFIX_PATTERNS := {
@@ -25,6 +27,7 @@ const PBR_SUFFIX_PATTERNS := {
 	PBRSuffix.ROUGHNESS: '%s_roughness.%s',
 	PBRSuffix.EMISSION: '%s_emission.%s',
 	PBRSuffix.AO: '%s_ao.%s',
+	PBRSuffix.HEIGHT: '%s_height.%s'
 }
 
 var PBR_SUFFIX_TEXTURES := {
@@ -33,12 +36,14 @@ var PBR_SUFFIX_TEXTURES := {
 	PBRSuffix.ROUGHNESS: StandardMaterial3D.TEXTURE_ROUGHNESS,
 	PBRSuffix.EMISSION: StandardMaterial3D.TEXTURE_EMISSION,
 	PBRSuffix.AO: StandardMaterial3D.TEXTURE_AMBIENT_OCCLUSION,
+	PBRSuffix.HEIGHT: StandardMaterial3D.TEXTURE_HEIGHTMAP
 }
 
 const PBR_SUFFIX_PROPERTIES := {
 	PBRSuffix.NORMAL: 'normal_enabled',
 	PBRSuffix.EMISSION: 'emission_enabled',
 	PBRSuffix.AO: 'ao_enabled',
+	PBRSuffix.HEIGHT: 'heightmap_enabled',
 }
 
 # Parameters


### PR DESCRIPTION
Depth maps appear to have been replaced with height maps in Godot 4.0, so I've added height maps into the layers which Qodot uses in auto-pbr. The suffix height maps should use is `_height`