### PR TITLE
Fix for CollisionShape3D; too many vertices

### DIFF
--- a/addons/qodot/src/core/SurfaceGatherer.cs
+++ b/addons/qodot/src/core/SurfaceGatherer.cs
@@ -56,7 +56,6 @@ namespace Qodot
 				Span<BrushGeometry> brushGeoSpan = mapData.GetBrushGeoSpan(e);
 				for (int b = 0; b < brushGeoSpan.Length; b++)
 				{
-					if(FilterBrush(e, b)) continue;
 
 					if (splitType == SurfaceSplitType.BRUSH)
 					{
@@ -79,7 +78,7 @@ namespace Qodot
 							{
 								vertexSpan[v].vertex -= entitySpan[e].center;
 							}
-							
+							if(FilterBrush(e, b)) continue;
 							outSurfaces[surfIdx].vertices.Add(vertexSpan[v]);
 						}
 						

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -729,8 +729,9 @@ func build_entity_collision_shapes() -> void:
 			else:
 				var shape_points = PackedVector3Array()
 				for vertex in surface_verts[Mesh.ARRAY_VERTEX]:
+					vertex += entity_position
 					if not vertex in shape_points:
-						shape_points.append(vertex + entity_position)
+						shape_points.append(vertex)
 				
 				var shape = ConvexPolygonShape3D.new()
 				shape.set_points(shape_points)


### PR DESCRIPTION
~~Unfortunately this doesn't fix grouped brushes with skip texture applied being in the wrong position.~~

~~I'm not 100%, but I think that bug originates from SurfaceGatherer.cs line 59 'FilterBrush'~~

~~Those brushes get skipped over without being placed properly~~

Edit: Moved the FilterBrush call, it works as expected now, but this probably isn't the correct way to do it. This pr can get users back to working on their games for now