### PR TITLE
Add old example scenes descriptions

### DIFF
--- a/addons/qodot/example_scenes/0-visuals/0-structural-geometry/0-structural-geometry.tscn
+++ b/addons/qodot/example_scenes/0-visuals/0-structural-geometry/0-structural-geometry.tscn
@@ -167,6 +167,9 @@ points = PackedVector3Array(-1, 0, -2, 1, 0, -2, 1, 6, -2, -1, 6, -2, -1.5, 6.5,
 [node name="StructuralGeometry" type="Node3D"]
 
 [node name="README" type="Node" parent="."]
+editor_description = "This scene illustrates the most basic use of Qodot: Building geometry from a map file.
+
+Note that because map files are referenced by global filesystem paths, you will need to set the `Map File` property on the QodotMap node to the equivalent of `res://scenes/examples/0-visuals/0-structural-geometry/0-structural-geometry.map` in order to successfully rebuild."
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")

--- a/addons/qodot/example_scenes/0-visuals/1-textures/1-textures.tscn
+++ b/addons/qodot/example_scenes/0-visuals/1-textures/1-textures.tscn
@@ -200,6 +200,15 @@ points = PackedVector3Array(-10, 2, -14, -10, 1, -14, -4, 1, -14, -4, 2, -14, -1
 [node name="Textures" type="Node3D"]
 
 [node name="README" type="Node" parent="."]
+editor_description = "This scene builds on the previous one by introducing textures.
+
+Textures are stored in the form `group/name` inside map files. When building a map, Qodot searches the base texture path defined in its properties for subfolders representing texture groups, and looks inside those for files matching the given texture name.
+
+If a texture is found, it will be applied to the `Albedo` slot of the `SpatialMaterial` resource set on the `Default Material` property of QodotMap. This behavior can be overridden with custom materials, which will be covered in the next scene.
+
+Note that a texture must reside in a group folder in order for Qodot to detect it. Any textures stored inside the base texture directory will be skipped, as they do not belong to a group and thus cannot be referenced by a map file.
+
+See `res://textures` for the layout used in this project."
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")

--- a/addons/qodot/example_scenes/0-visuals/2-materials/2-materials.tscn
+++ b/addons/qodot/example_scenes/0-visuals/2-materials/2-materials.tscn
@@ -219,6 +219,15 @@ shadow_enabled = true
 environment = SubResource("Environment_oop8v")
 
 [node name="README" type="Node" parent="."]
+editor_description = "This scene introduces automatic material application. In addition to textures, Qodot can apply custom materials to the brush geometry imported from a map file. This is done by coupling materials to texture names, allowing each texture to represent any material type supported by the engine.
+
+Practically speaking, this means storing a material next to its texture file with the same name, at which point Qodot will detect it during build and apply it instead of the default material.
+
+A simple use for this would be overriding the default properties of a `SpatialMaterial`, allowing for the customization of parameters like roughness, metallic and emission. The floor, fence and objects in the corners all use this technique.
+
+You could also couple a dummy texture with a `ShaderMaterial`, allowing that texture to represent some effect instead. The central object uses this technique to apply a shader that visualizes mesh tangents.
+
+Materials can also be loaded without a texture of the same name as a sibling file, but meshes generated with it will lack UVs and any other vertex property that requires texture size to be known at build time."
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")

--- a/addons/qodot/example_scenes/0-visuals/3-auto-pbr/3-auto-pbr.tscn
+++ b/addons/qodot/example_scenes/0-visuals/3-auto-pbr/3-auto-pbr.tscn
@@ -59,6 +59,21 @@ shadow_enabled = true
 environment = SubResource("Environment_xhgds")
 
 [node name="README" type="Node" parent="."]
+editor_description = "This scene introduces automatic PBR application.
+
+The standard `SpatialMaterial` used for rendering in Godot supports much more than the basic Albedo channel specified in a map file. Qodot accounts for this by allowing for the automatic application of the normal, metallic, roughness, emission, ambient occlusion and depth texture channels.
+
+These can be enabled by creating a folder with the same name as your texture, and storing it alongside it in the filesystem. Textures with specific prefixes stored in this folder will be treated as custom texture channels to be applied alongside their parent texture.
+
+The default prefixes are as follows:
+Normal - texture-name_normal.extension
+Metallic - texture-name_metallic.extension
+Roughness - texture-name_roughness.extension
+Emission - texture-name_emission.extension
+Ambient Occlusion - texture-name_ao.extension
+Depth - texture-name_depth.extension
+
+These can be modified in the `Qodot/Textures` category of the Project Settings window, and are stored in Godot's standard string matching format. For example, the default normal pattern is `%s_normal.%s`, and will have the first %s replaced with the texture name, and the second %s replaced with the texture extension specified on the QodotMap node."
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")

--- a/addons/qodot/example_scenes/0-visuals/4-special-textures/4-special-textures.tscn
+++ b/addons/qodot/example_scenes/0-visuals/4-special-textures/4-special-textures.tscn
@@ -109,6 +109,14 @@ transform = Transform3D(-0.866023, -0.433016, 0.250001, 0, 0.499998, 0.866027, -
 shadow_enabled = true
 
 [node name="README" type="Node" parent="."]
+editor_description = "This scene introduces special textures.
+
+The Quake workflow has certain texture names reserved for specific functions. Of these, the ones most relevant to Qodot are CLIP and SKIP.
+
+When fully textured with CLIP, a brush will omit its visuals from the build, but remain for the purposes of collision. This can be used to round off hard edges for smoother collision, or to create invisible walls.
+
+When textured with SKIP, a face will omit its visuals from the build. This can be used to manually hide hidden surfaces as an optimization, or for various visual tricks using one-sided geometry."
+
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")

--- a/addons/qodot/example_scenes/0-visuals/5-baked-lighting/5-1-baked-lightmaps.tscn
+++ b/addons/qodot/example_scenes/0-visuals/5-baked-lighting/5-1-baked-lightmaps.tscn
@@ -562,6 +562,23 @@ points = PackedVector3Array(0, 7.13824, -2, 0, 7.13824, -2, -1.90735e-06, 7.1382
 environment = SubResource("Environment_8h02o")
 
 [node name="README" type="Node" parent="."]
+editor_description = "This scene introduces static lightmap baking.
+
+(NOTE: Due to the filesize of baked lighting data, this scene ships without it for git-friendliness. Make sure to rebake the BakedLightmap node for correct visual results.)
+
+Godot supports baking out lightmap textures to be used instead of dynamic lights at runtime, commonly used to increase performance and work around the limitations of the dynamic lighting system.
+
+This requires a properly-unwrapped UV2 channel for any meshes being baked, so Qodot offers the ability to unwrap the generated meshes for an entire map via the 'Unwrap UV2' button in the top bar of the 3D view.
+
+Qodot marks built meshes for light baking based on the `Spawn Type` property specified in their FGD entry. By default, this includes all static non-entity geometry, otherwise known as 'worldspawn' in Quake terminology. Entity brushes can opt into light baking by specifying a `_shadow` property with a value of `1` in the map editor.
+
+Lights should have their `Bake Mode` property set to either `Indirect` or `All` in order to bake. `Indirect` is a hybrid mode that uses dynamic lighting for direct light and static lighting for indirect light, whereas `All` is designed to bake both direct and indirect lighting.
+
+If baking with `All`, a light should by hidden by disabling its render layer flags. This will allow the `BakedLightmap` node to detect it (unlike disabling visibility) and prevent it from rendering direct light dynamically.
+(Note that this does not work for directional lights as of 3.2. It's recommended to use a dynamic  light with `Indirect` set if you want to bake directional lighting.)
+
+Unfortunately the Godot light baker has some issues as of 3.2, and thus is not recommended for production usage. This is being addressed with a rewrite in 4.0, so for now this scene exists as a form of future-proofing."
+
 
 [node name="BakedLightmap" type="LightmapGI" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 8, 0)

--- a/addons/qodot/example_scenes/1-interactivity/0-point-entities/0-point-entities.tscn
+++ b/addons/qodot/example_scenes/1-interactivity/0-point-entities/0-point-entities.tscn
@@ -105,6 +105,17 @@ points = PackedVector3Array(11, 9.99999, 20, -11, 9.99999, 20, -11, 0, 21, 11, 0
 environment = SubResource("Environment_1ep67")
 
 [node name="README" type="Node" parent="."]
+editor_description = "This scene introduces point entities.
+
+Point entities are essentially actors - they map to Godot Spatial nodes and their subclasses, since they represent a point in 3D space with some associated functionality.
+
+Qodot implements these using an FGD. Short for 'Forge Game Data', FGD is a format created by Valve as an interchange format for defining game object data such as actors and their properties, and has become the de-facto standard for development and modding of Quake-derived games.
+
+Point entities are one of the types of class that can be defined in an FGD, and can be used to spawn custom node types or instanced scenes with optional attached scripts. In this case, the physics balls are simple entities with no special behavior or properties that instance a scene containing a RigidBody and its collision rig.
+
+Entities all have a key-value dictionary of properties that can be configured via map editor, then imported and applied to objects in Godot. The QodotEntity class implements this along with an on-change handler for convenient subclassing, but Qodot uses duck-typing for the purposes of populating this property so you can create your own implementation without needing to extend a built-in class.
+
+An example FGD is available at `res://addons/qodot/game-definitions/fgd/qodot-fgd.tres`."
 
 [node name="DirectionalLight" type="DirectionalLight3D" parent="."]
 transform = Transform3D(-0.5, 0.612372, -0.612372, 0, 0.707107, 0.707107, 0.866025, 0.353553, -0.353554, 0, 15, 0)

--- a/addons/qodot/example_scenes/1-interactivity/1-brush-entities/1-brush-entities.tscn
+++ b/addons/qodot/example_scenes/1-interactivity/1-brush-entities/1-brush-entities.tscn
@@ -224,6 +224,18 @@ points = PackedVector3Array(8, -0.499998, 9.08333, 8, 0.5, 9.08333, -8, 0.5, 9.0
 environment = SubResource("Environment_ya28d")
 
 [node name="README" type="Node" parent="."]
+editor_description = "This scene introduces brush entities.
+
+Like point entities, brush entities also map to the concept of an actor, but one whose geometry is determined by geometry from a map file instead of some pre-existing rig stored as a script or scene.
+
+Qodot implements these using an FGD. Short for 'Forge Game Data', FGD is a format created by Valve as an interchange format for defining game object data such as actors and their properties, and has become the de-facto standard for development and modding of Quake-derived games.
+
+Brush entities are one of the types of class that can be defined in an FGD, and can be used to spawn custom node types with an attached mesh instance and optional collision. In this case, the hammer and column are a set of simple `RigidBody` nodes with attached `MeshInstance` and `CollisionShape` children generated from their brush geometry.
+
+Entities all have a key-value dictionary of properties that can be configured via map editor, then imported and applied to objects in Godot. The QodotEntity class implements this along with an on-change handler for convenient subclassing, but Qodot uses duck-typing for the purposes of populating this property so you can create your own implementation without needing to extend a built-in class.
+
+An example FGD is available at `res://addons/qodot/game-definitions/fgd/qodot-fgd.tres`."
+
 
 [node name="DirectionalLight" type="DirectionalLight3D" parent="."]
 transform = Transform3D(-0.5, 0.612372, -0.612372, 0, 0.707107, 0.707107, 0.866025, 0.353553, -0.353554, 0, 15, 0)

--- a/addons/qodot/example_scenes/1-interactivity/2-worldspawn-layers/2-worldspawn-layers.tscn
+++ b/addons/qodot/example_scenes/1-interactivity/2-worldspawn-layers/2-worldspawn-layers.tscn
@@ -178,6 +178,15 @@ points = PackedVector3Array(28, 20, 24, 28, 16, 24, 32, 16, 24, 32, 20, 24, 28, 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource("Environment_fkxce")
 
+[node name="README" type="Node" parent="."]
+editor_description = "This scene introduces worldspawn layers.
+
+In Quake, there are certain textures that apply special behavior or properties to brushes, such as water, slime, and lava. Worldspawn layers are the Qodot equivalent - scriptable volumes defined by a texture that don't have a FGD entry or properties as an entity would.
+
+Worldspawn layers are defined as a `Resource` subclass in Godot, and are plugged into the `Worldspawn Layers` property of QodotMap in order to supply the requisite information to the build system. You can define their name, texture, visual build, collision type, and associated script in order to implement custom behavior.
+
+In this case, each layer uses a script that inherits from the `Liquid` class, which extends `Area` and applies buoyancy and damping forces based on a calculated displacement value. Each subclass sets its properties inside `_init_`, which allows for different behavior per layer."
+
 [node name="DirectionalLight" type="DirectionalLight3D" parent="."]
 transform = Transform3D(-0.5, 0.612372, -0.612372, 0, 0.707107, 0.707107, 0.866025, 0.353553, -0.353554, 0, 15, 0)
 light_energy = 0.8

--- a/addons/qodot/example_scenes/1-interactivity/3-basic-signal-wiring/3-basic-signal-wiring.tscn
+++ b/addons/qodot/example_scenes/1-interactivity/3-basic-signal-wiring/3-basic-signal-wiring.tscn
@@ -270,6 +270,13 @@ points = PackedVector3Array(-0.5, 3.5, -3, -0.5, -3.5, -3, 0.5, -3.5, -3, 0.5, 3
 environment = SubResource("Environment_yrqpb")
 
 [node name="README" type="Node" parent="."]
+editor_description = "This scene introduces basic signal wiring.
+
+In Quake, objects are connected together via their `target` and `targetname` fields. `targetname` tags an entity as an event receiver using the provided string ID, and `target` is used to reference one of these string IDs as the target of an event sender.
+This setup doesn't allow any parameters to be passed, but is simple, allows for one-to-many relationships, and allows for creating interactive behavior with minimal configuration overhead.
+
+In Qodot, this is implemented using signals. Event sender scripts should define a `trigger()` signal to be emitted on activation, and event receiver scripts should specify a `use()` method for this signal to invoke. If connected `targetname` and `target` fields are present, Qodot will attempt to connect the sender's `trigger()` to the receiver's `use()` as a persistent signal during map build"
+
 
 [node name="DirectionalLight" type="DirectionalLight3D" parent="."]
 transform = Transform3D(-0.5, 0.612372, -0.612372, 0, 0.707107, 0.707107, 0.866025, 0.353553, -0.353554, 0, 15, 0)

--- a/addons/qodot/example_scenes/1-interactivity/4-advanced-signal-wiring/4-advanced-signal-wiring.tscn
+++ b/addons/qodot/example_scenes/1-interactivity/4-advanced-signal-wiring/4-advanced-signal-wiring.tscn
@@ -162,6 +162,18 @@ points = PackedVector3Array(-2, 0.5, -2, -2, -0.5, -2, 2, -0.5, -2, 2, 0.5, -2, 
 environment = SubResource("Environment_hpogl")
 
 [node name="README" type="Node" parent="."]
+editor_description = "This scene introduces advanced signal wiring.
+
+Unlike the Quake event model, Godot's signal / receiver method mechanism allows each object to emit or receive multiple signals with specific parameters. To account for this, Qodot implements an advanced signal wiring mechanism driven by point entities.
+
+To use it, you can add `signal` and `receiver` point entities inside the map editor.
+
+The `signal` entity takes a `targetname` property that should be referenced in the `target` property of the object emitting the signal, and a `signal_name` property that defines which signal is being connected, as well as a `target` property referencing the `targetname` of the receiver object being targeted..
+
+The `receiver` entity takes a `targetname` property that should be referenced in the `target` property of the `signal` entity that should connect to it, as well as a `receiver_name` that defines which receiver method is being targeted, and a `target` property referencing the `targetname` property of the object whose receiver method should be connected.
+
+This structure forms a chain of entity > signal > receiver > entity, and encodes all of the necessary information for Qodot to detect and connect the necessary signals at build time. Entities can have multiple sets of signals and receivers connected to them, allowing for complex interactions between objects."
+
 
 [node name="DirectionalLight" type="DirectionalLight3D" parent="."]
 transform = Transform3D(-0.5, 0.612372, -0.612372, 0, 0.707107, 0.707107, 0.866025, 0.353553, -0.353554, 0, 15, 0)

--- a/addons/qodot/example_scenes/2-miscallaneous/0-trenchbroom-group-hierarchy/0-trenchbroom-group-hierarchy.tscn
+++ b/addons/qodot/example_scenes/2-miscallaneous/0-trenchbroom-group-hierarchy/0-trenchbroom-group-hierarchy.tscn
@@ -99,6 +99,13 @@ shadow_enabled = true
 environment = SubResource("Environment_1ktpt")
 
 [node name="README" type="Node" parent="."]
+editor_description = "This scene introduces nested TrenchBroom groups.
+
+By default the Quake map format uses a flat hierarchy for each of its types - the map itself contains entities, and the entities contain brushes. It has no concept of parenting or attachment. However, TrenchBroom implements a nestable grouping system using metadata attached to func_group entities.
+
+If the `TrenchBroom Group Hierarchy` property is enabled on a QodotMap node, these func_group entities will be parsed into a tree hierarchy during build.
+
+Note that groups may only contain a single entity brush, structural brushes, and other groups. This is because a single entity needs to be chosen to represent each group in the scene tree."
 
 [node name="Camera" type="Camera3D" parent="."]
 transform = Transform3D(0.587785, 0.25, -0.769421, 0, 0.951057, 0.309017, 0.809017, -0.181636, 0.559017, -32.8446, 21.3321, 23.8013)

--- a/addons/qodot/example_scenes/2-miscallaneous/1-runtime-map-building/1-runtime-map-building.tscn
+++ b/addons/qodot/example_scenes/2-miscallaneous/1-runtime-map-building/1-runtime-map-building.tscn
@@ -29,6 +29,11 @@ shadow_enabled = true
 environment = SubResource("Environment_wgi4p")
 
 [node name="README" type="Node" parent="."]
+editor_description = "This scene introduces runtime map building.
+
+Qodot usage isn't limited only to the editor - if you ship the requisite platform-specific native libraries with your project, you can invoke map builds at runtime using the `verify_and_build()` function in QodotMap to allow for user map creation.
+
+Note that only in-project WAD files are currently supported for runtime builds, as their implementation is tightly coupled to the Godot resource system."
 
 [node name="OrbitCameraController" type="Node3D" parent="."]
 transform = Transform3D(0.85264, -0.245298, 0.461339, 0, 0.882947, 0.469472, -0.522499, -0.40029, 0.752836, 1.73346, -1.42268, -7.17249)


### PR DESCRIPTION
From issue #29, old scenes descriptions were missing in the migration to Godot 4.

Added them as editor_description. Before they were in readme nodes as
```
 __meta__ = {
"_editor_description_": ""
}
```
which was the Godot 3.x way.