### PR TITLE
Change the path to get map

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -98,7 +98,7 @@ func _ready() -> void:
 func _get_property_list() -> Array:
 	return [
 		QodotUtil.category_dict('Map'),
-		QodotUtil.property_dict('map_file', TYPE_STRING, PROPERTY_HINT_GLOBAL_FILE, '*.map'),
+		QodotUtil.property_dict('map_file', TYPE_STRING, PROPERTY_HINT_FILE, '*.map'),
 		QodotUtil.property_dict('inverse_scale_factor', TYPE_INT),
 		QodotUtil.category_dict('Entities'),
 		QodotUtil.property_dict('entity_fgd', TYPE_OBJECT, PROPERTY_HINT_RESOURCE_TYPE, 'Resource'),


### PR DESCRIPTION
Sorry, but I don't know how to explain it very well.
Basically, before it compiled the map through the global path (c:/users/user_name/project_folder/map_location.map) which broke the use of github a little since I would have to change all the time to be able to compile, I couldn't do it myself work with this with several people, but I changed it and now instead of getting the global size, it gets the size from the project folder