### PR TITLE
Document a bunch of classes

### DIFF
--- a/addons/qodot/src/nodes/qodot_entity.gd
+++ b/addons/qodot/src/nodes/qodot_entity.gd
@@ -1,6 +1,14 @@
 class_name QodotEntity
 extends QodotNode3D
 
+## Base class for entities created by Qodot
+##
+## This is an abstract base class. In order to create a QodotEntity-derived node, derived classes should be assigned to a [member QodotFGDPointClass.script_class] or [member QodotFGDSolidClass.script_class], so they can be instanced during the building of a [QodotMap] node.
+## Derived classes should override [method update_properties].
+##
+## @tutorial: https://qodotplugin.github.io/docs/entities/scripting-entities
+
+## Properties for this entity. Populated from Trenchbroom's entity property editor when building a [QodotMap].
 @export var properties: Dictionary :
 	get:
 		return properties # TODOConverter40 Non existent get function 
@@ -9,6 +17,7 @@ extends QodotNode3D
 			properties = new_properties
 			update_properties()
 
+## Handle updates to [member properties]
 func update_properties() -> void:
 	pass
 

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -8,6 +8,7 @@ extends QodotNode3D
 ## the definitions for entities, textures, and materials that appear in the map.
 ## To use this node, select an instance of the node in the Godot editor and
 ## select "Quick Build", "Full Build", or "Unwrap UV2" from the toolbar.
+## Alternatively, call [method manual_build] from code.
 ##
 ## @tutorial: https://qodotplugin.github.io/docs/beginner's-guide-to-qodot/
 
@@ -18,24 +19,28 @@ const YIELD_DURATION := 0.0
 ## Unused
 const YIELD_SIGNAL := "timeout"
 
+## Emitted when the build process successfully completes
 signal build_complete()
+## Emitted when the build process finishes a step. [code]progress[/code] is from 0.0-1.0
 signal build_progress(step, progress)
+## Emitted when the build process fails
 signal build_failed()
 
+## Emitted when UV2 unwrapping is completed
 signal unwrap_uv2_complete()
 
 @export_category("Map")
 ## Trenchbroom Map file to build a scene from
 @export_global_file("*.map") var map_file := ""
 ## Ratio between Trenchbroom units in the .map file and Godot units.
-## An inverse_scale_factor of 16 would cause 16 Trenchbroom units to correspond to 1 Godot unit. See [url=https://qodotplugin.github.io/docs/geometry.html#scale]Scale[/url] in the Qodot documentation.
+## An inverse scale factor of 16 would cause 16 Trenchbroom units to correspond to 1 Godot unit. See [url=https://qodotplugin.github.io/docs/geometry.html#scale]Scale[/url] in the Qodot documentation.
 @export var inverse_scale_factor := 16.0
 @export_category("Entities")
 ## [QodotFGDFile] for the map.
 ## This resource will translate between Trenchbroom classnames and Godot scripts/scenes. See [url=https://qodotplugin.github.io/docs/entities/]Entities[/url] in the Qodot manual.
 @export var entity_fgd: QodotFGDFile = load("res://addons/qodot/game_definitions/fgd/qodot_fgd.tres")
 @export_category("Textures")
-## Base directory for textures. When building materials, Qodot will search this directory for textures matching the textures assigned to Trenchbroom faces.
+## Base directory for textures. When building materials, Qodot will search this directory for texture files matching the textures assigned to Trenchbroom faces.
 @export_dir var base_texture_dir := "res://textures"
 ## File extensions to search for texture data.
 @export var texture_file_extensions := PackedStringArray(["png"])
@@ -61,18 +66,19 @@ signal unwrap_uv2_complete()
 ## Default albedo texture (used when [member default_material] is a [ShaderMaterial])
 @export var default_material_albedo_uniform := ""
 @export_category("UV Unwrap")
-## Texel size for UV unwrap.
+## Texel size for UV2 unwrapping.
+## A texel size of 1 will lead to a 1:1 correspondence between texture texels and lightmap texels. Larger values will produce less detailed lightmaps. To conserve memory and filesize, use the largest value that still looks good.
 @export var uv_unwrap_texel_size := 1.0
 @export_category("Build")
 ## If true, print profiling data before and after each build step
 @export var print_profiling_data := false
-## If true, Qodot will build a hierarchy from Trenchbroom groups, each group being a node. Otherwise, Qodot entities will have a flat structure.
+## If true, Qodot will build a hierarchy from Trenchbroom groups, each group being a node. Otherwise, Qodot nodes will ignore Trenchbroom groups and have a flat structure.
 @export var use_trenchbroom_group_hierarchy := false
 ## If true, stop the whole editor until build is complete
 @export var block_until_complete := false
 ## Unused
 @export var tree_attach_batch_size := 0
-## How many nodes to set the owner of at once. Higher values may lead to quicker build times, but a less responsive editor.
+## How many nodes to set the owner of, or add children of, at once. Higher values may lead to quicker build times, but a less responsive editor.
 @export var set_owner_batch_size := 1000
 
 # Build context variables
@@ -120,12 +126,13 @@ func verify_and_build():
 	else:
 		emit_signal("build_failed")
 
+## Build the map.
 func manual_build():
 	should_add_children = false
 	should_set_owners = false
 	verify_and_build()
 
-## Return true if Qodot is functioning and [member map_file] exists.
+## Return true if parameters are valid; Qodot should be functioning and [member map_file] should exist.
 func verify_parameters():
 	if not qodot or DEBUG:
 		qodot = load("res://addons/qodot/src/core/Qodot.cs").new()
@@ -144,6 +151,7 @@ func verify_parameters():
 	
 	return true
 
+## Reset member variables that affect the current build
 func reset_build_context():
 	add_child_array = []
 	set_owner_array = []
@@ -170,12 +178,13 @@ func reset_build_context():
 	
 	if qodot:
 		qodot.Reset()
-
+## Record the start time of a build step for profiling
 func start_profile(item_name: String) -> void:
 	if print_profiling_data:
 		print(item_name)
 		profile_timestamps[item_name] = Time.get_ticks_usec()
 
+## Finish profiling for a build step; print associated timing data
 func stop_profile(item_name: String) -> void:
 	if print_profiling_data:
 		if item_name in profile_timestamps:
@@ -183,6 +192,7 @@ func stop_profile(item_name: String) -> void:
 			print("Done in %s sec\n" % [delta * 0.000001])
 			profile_timestamps.erase(item_name)
 
+## Run a build step. [code]step_name[/code] is the method corresponding to the step, [code]params[/code] are parameters to pass to the step, and [code]func_name[/code] does nothing.
 func run_build_step(step_name: String, params: Array = [], func_name: String = ""):
 	start_profile(step_name)
 	if func_name == "":
@@ -191,6 +201,7 @@ func run_build_step(step_name: String, params: Array = [], func_name: String = "
 	stop_profile(step_name)
 	return result
 
+## Add [code]node[/code] as a child of parent, or as a child of [code]below[/code] if non-null. Also queue for ownership assignment.
 func add_child_editor(parent, node, below = null) -> void:
 	var prev_parent = node.get_parent()
 	if prev_parent:
@@ -203,6 +214,7 @@ func add_child_editor(parent, node, below = null) -> void:
 	
 	set_owner_array.append(node)
 
+## Set the owner of [code]node[/code] to the current scene.
 func set_owner_editor(node):
 	var tree := get_tree()
 	
@@ -221,10 +233,14 @@ var build_step_count := 0
 var build_steps := []
 var post_attach_steps := []
 
+## Register a build step.
+## [code]build_step[/code] is a string that corresponds to a method on this class, [code]arguments[/code] a list of arguments to pass to this method, and [code]target[/code] is a property on this class to save the return value of the build step in. If [code]post_attach[/code] is true, the step will be run after the scene hierarchy is completed.
 func register_build_step(build_step: String, arguments := [], target := "", post_attach := false) -> void:
 	(post_attach_steps if post_attach else build_steps).append([build_step, arguments, target])
 	build_step_count += 1
 
+## Run all build steps. Emits [signal build_progress] after each step.
+## If [code]post_attach[/code] is true, run post-attach steps instead and signal [signal build_complete] when finished.
 func run_build_steps(post_attach := false) -> void:
 	var target_array = post_attach_steps if post_attach else build_steps
 	
@@ -248,6 +264,7 @@ func run_build_steps(post_attach := false) -> void:
 		start_profile('add_children')
 		add_children()
 
+## Register all steps for the build. See [method register_build_step] and [method run_build_steps]
 func register_build_steps() -> void:
 	register_build_step('remove_children')
 	register_build_step('load_map')
@@ -272,6 +289,7 @@ func register_build_steps() -> void:
 	register_build_step('build_entity_collision_shape_nodes', [], 'entity_collision_shapes')
 	register_build_step('build_worldspawn_layer_collision_shape_nodes', [], 'worldspawn_layer_collision_shapes')
 
+## Register all post-attach steps for the build. See [method register_build_step] and [method run_build_steps]
 func register_post_attach_steps() -> void:
 	register_build_step('build_entity_collision_shapes', [], "", true)
 	register_build_step('build_worldspawn_layer_collision_shapes', [], "", true)
@@ -282,6 +300,7 @@ func register_post_attach_steps() -> void:
 	register_build_step('remove_transient_nodes', [], "", true)
 
 # Actions
+## Build the map
 func build_map() -> void:
 	reset_build_context()
 	
@@ -293,6 +312,7 @@ func build_map() -> void:
 	
 	run_build_steps()
 
+## Recursively unwrap UV2s for [code]node[/code] and its children, in preparation for baked lighting.
 func unwrap_uv2(node: Node = null) -> void:
 	var target_node = null
 	
@@ -315,19 +335,22 @@ func unwrap_uv2(node: Node = null) -> void:
 		emit_signal("unwrap_uv2_complete")
 
 # Build Steps
-
+## Recursively remove and delete all children of this node
 func remove_children() -> void:
 	for child in get_children():
 		remove_child(child)
 		child.queue_free()
 
+## Parse and load [member map_file]
 func load_map() -> void:
 	var file: String = map_file
 	qodot.LoadMap(file)
 
+## Get textures found in [member map_file]
 func fetch_texture_list() -> Array:
 	return qodot.GetTextureList() as Array
 
+## Initialize texture loader, allowing textures in [member base_texture_dir] and [member texture_wads] to be turned into materials
 func init_texture_loader() -> QodotTextureLoader:
 	var tex_ldr := QodotTextureLoader.new(
 		base_texture_dir,
@@ -337,31 +360,40 @@ func init_texture_loader() -> QodotTextureLoader:
 	tex_ldr.unshaded = unshaded
 	return tex_ldr
 
+## Build a dictionary from Trenchbroom texture names to their corresponding Texture2D resources in Godot
 func load_textures() -> Dictionary:
 	return texture_loader.load_textures(texture_list) as Dictionary
 
+## Build a dictionary from Trenchbroom texture names to Godot materials
 func build_materials() -> Dictionary:
 	return texture_loader.create_materials(texture_list, material_file_extension, default_material, default_material_albedo_uniform)
 
+## Collect entity definitions from [member entity_fgd], as a dictionary from Trenchbroom classnames to entity definitions
 func fetch_entity_definitions() -> Dictionary:
 	return entity_fgd.get_entity_definitions()
 
+## Hand the Qodot C# core the entity definitions
 func set_qodot_entity_definitions() -> void:
 	qodot.SetEntityDefinitions(build_libmap_entity_definitions(entity_definitions))
 
+## Hand the Qodot C# core the worldspawn layer definitions. See [member worldspawn_layers]
 func set_qodot_worldspawn_layers() -> void:
 	qodot.SetWorldspawnLayers(build_libmap_worldspawn_layers(worldspawn_layers))
 
+## Generate geometry from map file
 func generate_geometry() -> void:
 	qodot.GenerateGeometry(texture_size_dict);
 
+## Get a list of dictionaries representing each entity from the Qodot C# core
 func fetch_entity_dicts() -> Array:
 	return qodot.GetEntityDicts()
 
+## Get a list of dictionaries representing each worldspawn layer from the Qodot C# core
 func fetch_worldspawn_layer_dicts() -> Array:
 	var layer_dicts = qodot.GetWorldspawnLayerDicts()
 	return layer_dicts if layer_dicts else []
 
+## Build a dictionary from Trenchbroom textures to the sizes of their corresponding Godot textures
 func build_texture_size_dict() -> Dictionary:
 	var texture_size_dict := {}
 	
@@ -374,6 +406,7 @@ func build_texture_size_dict() -> Dictionary:
 	
 	return texture_size_dict
 
+## Marshall Qodot FGD definitions for transfer to libmap
 func build_libmap_entity_definitions(entity_definitions: Dictionary) -> Dictionary:
 	var libmap_entity_definitions = {}
 	for classname in entity_definitions:
@@ -382,6 +415,7 @@ func build_libmap_entity_definitions(entity_definitions: Dictionary) -> Dictiona
 			libmap_entity_definitions[classname]['spawn_type'] = entity_definitions[classname].spawn_type
 	return libmap_entity_definitions
 
+## Marshall worldspawn layer definitions for transfer to libmap
 func build_libmap_worldspawn_layers(worldspawn_layers: Array) -> Array:
 	var libmap_worldspawn_layers := []
 	for worldspawn_layer in worldspawn_layers:
@@ -395,6 +429,7 @@ func build_libmap_worldspawn_layers(worldspawn_layers: Array) -> Array:
 		})
 	return libmap_worldspawn_layers
 
+## Build nodes from the entities in [member entity_dicts]
 func build_entity_nodes() -> Array:
 	var entity_nodes := []
 
@@ -451,6 +486,7 @@ func build_entity_nodes() -> Array:
 	
 	return entity_nodes
 
+## Build nodes from the worldspawn layers in [member worldspawn_layers]
 func build_worldspawn_layer_nodes() -> Array:
 	var worldspawn_layer_nodes := []
 	
@@ -465,6 +501,7 @@ func build_worldspawn_layer_nodes() -> Array:
 	
 	return worldspawn_layer_nodes
 
+## Resolve entity group hierarchy, turning Trenchbroom groups into nodes and queueing their contents to be added to said nodes as children
 func resolve_group_hierarchy() -> void:
 	if not use_trenchbroom_group_hierarchy:
 		return
@@ -560,6 +597,7 @@ func resolve_group_hierarchy() -> void:
 		
 		queue_add_child(parent, child, null, true)
 
+## Return the node associated with a Trenchbroom index. Unused.
 func get_node_by_tb_id(target_id: String, entity_nodes: Dictionary):
 	for node_idx in entity_nodes:
 		var node = entity_nodes[node_idx]
@@ -581,6 +619,7 @@ func get_node_by_tb_id(target_id: String, entity_nodes: Dictionary):
 		
 	return null
 
+## Build [CollisionShape3D] nodes for brush entities
 func build_entity_collision_shape_nodes() -> Array:
 	var entity_collision_shapes_arr := []
 	
@@ -628,6 +667,7 @@ func build_entity_collision_shape_nodes() -> Array:
 	
 	return entity_collision_shapes_arr
 
+## Build CollisionShape3D nodes for worldspawn layers
 func build_worldspawn_layer_collision_shape_nodes() -> Array:
 	var worldspawn_layer_collision_shapes := []
 	
@@ -669,6 +709,7 @@ func build_worldspawn_layer_collision_shape_nodes() -> Array:
 	
 	return worldspawn_layer_collision_shapes
 
+## Build the concrete [Shape3D] resources for each brush
 func build_entity_collision_shapes() -> void:
 	for entity_idx in range(0, entity_dicts.size()):
 		var entity_dict := entity_dicts[entity_idx] as Dictionary
@@ -740,6 +781,7 @@ func build_entity_collision_shapes() -> void:
 			var collision_shape = entity_collision_shapes[entity_idx][0]
 			collision_shape.set_shape(shape)
 
+## Build the concrete [Shape3D] resources for each worldspawn layer
 func build_worldspawn_layer_collision_shapes() -> void:
 	for layer_idx in range(0, worldspawn_layers.size()):
 		if layer_idx >= worldspawn_layer_dicts.size():
@@ -801,6 +843,7 @@ func build_worldspawn_layer_collision_shapes() -> void:
 			var collision_shape = worldspawn_layer_collision_shapes[layer_idx][0]
 			collision_shape.set_shape(shape)
 
+## Build Dictionary from entity indices to [ArrayMesh] instances
 func build_entity_mesh_dict() -> Dictionary:
 	var meshes := {}
 	
@@ -839,6 +882,7 @@ func build_entity_mesh_dict() -> Dictionary:
 			
 	return meshes
 
+## Build Dictionary from worldspawn layers (via textures) to [ArrayMesh] instances
 func build_worldspawn_layer_mesh_dict() -> Dictionary:
 	var meshes := {}
 	
@@ -858,6 +902,7 @@ func build_worldspawn_layer_mesh_dict() -> Dictionary:
 	
 	return meshes
 
+## Build [MeshInstance3D]s from brush entities and add them to the add child queue
 func build_entity_mesh_instances() -> Dictionary:
 	var entity_mesh_instances := {}
 	for entity_idx in entity_mesh_dict:
@@ -890,6 +935,7 @@ func build_entity_mesh_instances() -> Dictionary:
 	
 	return entity_mesh_instances
 
+## Build Dictionary from worldspawn layers (via textures) to [MeshInstance3D]s
 func build_worldspawn_layer_mesh_instances() -> Dictionary:
 	var worldspawn_layer_mesh_instances := {}
 	var idx = 0
@@ -916,6 +962,7 @@ func build_worldspawn_layer_mesh_instances() -> Dictionary:
 	
 	return worldspawn_layer_mesh_instances
 
+## Assign [ArrayMesh]es to their [MeshInstance3D] counterparts
 func apply_entity_meshes() -> void:
 	for entity_idx in entity_mesh_dict:
 		var mesh := entity_mesh_dict[entity_idx] as Mesh
@@ -928,6 +975,7 @@ func apply_entity_meshes() -> void:
 		
 		queue_add_child(entity_nodes[entity_idx], mesh_instance)
 
+## Assign [ArrayMesh]es to their [MeshInstance3D] counterparts for worldspawn layers
 func apply_worldspawn_layer_meshes() -> void:
 	for texture_name in worldspawn_layer_mesh_dict:
 		var mesh = worldspawn_layer_mesh_dict[texture_name]
@@ -938,9 +986,11 @@ func apply_worldspawn_layer_meshes() -> void:
 		
 		mesh_instance.set_mesh(mesh)
 
+## Add a child and its new parent to the add child queue. If [code]below[/code] is a node, add it as a child to that instead. If [code]relative[/code] is true, set the location of node relative to parent.
 func queue_add_child(parent, node, below = null, relative = false) -> void:
 	add_child_array.append({"parent": parent, "node": node, "below": below, "relative": relative})
 
+## Assign children to parents based on the contents of the add child queue (see [method queue_add_child])
 func add_children() -> void:
 	while true:
 		for i in range(0, set_owner_batch_size):
@@ -957,6 +1007,7 @@ func add_children() -> void:
 		if scene_tree and not block_until_complete:
 			await get_tree().create_timer(YIELD_DURATION).timeout
 
+## Set owners and start post-attach build steps
 func add_children_complete():
 	stop_profile('add_children')
 	
@@ -966,6 +1017,7 @@ func add_children_complete():
 	else:
 		run_build_steps(true)
 
+## Set owner of nodes generated by Qodot to scene root based on [member set_owner_array]
 func set_owners():
 	while true:
 		for i in range(0, set_owner_batch_size):
@@ -980,10 +1032,12 @@ func set_owners():
 		if scene_tree and not block_until_complete:
 			await get_tree().create_timer(YIELD_DURATION).timeout
 
+## Finish profiling for set_owners and start post-attach build steps
 func set_owners_complete():
 	stop_profile('set_owners')
 	run_build_steps(true)
 
+## Apply Trenchbroom properties to [QodotEntity] instances, transferring Trenchbroom dictionaries to [QodotEntity.properties]
 func apply_properties() -> void:
 	for entity_idx in range(0, entity_nodes.size()):
 		var entity_node = entity_nodes[entity_idx]
@@ -1036,6 +1090,7 @@ func apply_properties() -> void:
 		if 'properties' in entity_node:
 			entity_node.properties = properties
 
+## Wire signals based on Trenchbroom [code]target[/code] and [code]targetname[/code] properties
 func connect_signals() -> void:
 	for entity_idx in range(0, entity_nodes.size()):
 		var entity_node = entity_nodes[entity_idx]
@@ -1052,6 +1107,7 @@ func connect_signals() -> void:
 		for target_node in target_nodes:
 			connect_signal(entity_node, target_node)
 
+## Connect a signal on [code]entity_node[/code] to [code]target_node[/code], possibly mediated by the contents of a [code]signal[/code] or [code]receiver[/code] entity
 func connect_signal(entity_node: Node, target_node: Node) -> void:
 	if target_node.properties['classname'] == 'signal':
 		var signal_name = target_node.properties['signal_name']
@@ -1073,6 +1129,7 @@ func connect_signal(entity_node: Node, target_node: Node) -> void:
 				entity_node.connect("trigger",Callable(target_node,"use"),CONNECT_PERSIST)
 				break
 
+## Remove nodes marked transient. See [member QodotFGDClass.transient_node]
 func remove_transient_nodes() -> void:
 	for entity_idx in range(0, entity_nodes.size()):
 		var entity_node = entity_nodes[entity_idx]
@@ -1095,7 +1152,7 @@ func remove_transient_nodes() -> void:
 			entity_node.get_parent().remove_child(entity_node)
 			entity_node.queue_free()
 
-
+## Find all nodes with matching targetname property
 func get_nodes_by_targetname(targetname: String) -> Array:
 	var nodes := []
 	
@@ -1115,6 +1172,7 @@ func get_nodes_by_targetname(targetname: String) -> Array:
 	
 	return nodes
 
+# Cleanup after build is finished (internal)
 func _build_complete():
 	reset_build_context()
 	

--- a/addons/qodot/src/nodes/qodot_node3d.gd
+++ b/addons/qodot/src/nodes/qodot_node3d.gd
@@ -2,5 +2,6 @@
 class_name QodotNode3D
 extends Node3D
 
+## Unused internal function
 func get_class() -> String:
 	return 'QodotSpatial'

--- a/addons/qodot/src/qodot_plugin.gd
+++ b/addons/qodot/src/qodot_plugin.gd
@@ -85,11 +85,7 @@ func try_add_project_setting(name: String, type: int, value, info: Dictionary = 
 	if not ProjectSettings.has_setting(name):
 		add_project_setting(name, type, value, info)
 
-<<<<<<< HEAD
-## Add property with path name and type (from [enum @GlobalScript.Variant.Type]) to Project Settings, defaulting to value.
-=======
 ## Add property with path name and type from [enum @GlobalScope.Variant.Type] to Project Settings, defaulting to value.
->>>>>>> 3b52fb3 (Document QodotPlugin)
 ## Optionally, supply property info from info.
 func add_project_setting(name: String, type: int, value, info: Dictionary = {}) -> void:
 	ProjectSettings.set(name, value)
@@ -207,11 +203,7 @@ func set_qodot_map_control_disabled(disabled: bool) -> void:
 		if child is Button:
 			child.set_disabled(disabled)
 
-<<<<<<< HEAD
-## Update the build progress bar (see: []) to display the current step and progress (0-1)
-=======
 ## Update the build progress bar (see: [method create_qodot_map_progress_bar]) to display the current step and progress (0-1)
->>>>>>> 3b52fb3 (Document QodotPlugin)
 func qodot_map_build_progress(step: String, progress: float) -> void:
 	var progress_label = qodot_map_progress_bar.get_node("ProgressLabel")
 	qodot_map_progress_bar.value = progress

--- a/addons/qodot/src/qodot_plugin.gd
+++ b/addons/qodot/src/qodot_plugin.gd
@@ -71,6 +71,7 @@ func _exit_tree() -> void:
 	qodot_map_progress_bar.queue_free()
 	qodot_map_progress_bar = null
 
+## Add Qodot-specific settings to Godot's Project Settings
 func setup_project_settings() -> void:
 	try_add_project_setting('qodot/textures/normal_pattern', TYPE_STRING, QodotTextureLoader.PBR_SUFFIX_PATTERNS[QodotTextureLoader.PBRSuffix.NORMAL])
 	try_add_project_setting('qodot/textures/metallic_pattern', TYPE_STRING, QodotTextureLoader.PBR_SUFFIX_PATTERNS[QodotTextureLoader.PBRSuffix.METALLIC])
@@ -79,10 +80,13 @@ func setup_project_settings() -> void:
 	try_add_project_setting('qodot/textures/ao_pattern', TYPE_STRING, QodotTextureLoader.PBR_SUFFIX_PATTERNS[QodotTextureLoader.PBRSuffix.AO])
 	try_add_project_setting('qodot/textures/height_pattern', TYPE_STRING, QodotTextureLoader.PBR_SUFFIX_PATTERNS[QodotTextureLoader.PBRSuffix.HEIGHT])
 
+## Add property, if not already present. See [method add_project_setting] for usage.
 func try_add_project_setting(name: String, type: int, value, info: Dictionary = {}) -> void:
 	if not ProjectSettings.has_setting(name):
 		add_project_setting(name, type, value, info)
 
+## Add property with path name and type (from [enum @GlobalScript.Variant.Type]) to Project Settings, defaulting to value.
+## Optionally, supply property info from info.
 func add_project_setting(name: String, type: int, value, info: Dictionary = {}) -> void:
 	ProjectSettings.set(name, value)
 
@@ -93,6 +97,7 @@ func add_project_setting(name: String, type: int, value, info: Dictionary = {}) 
 	ProjectSettings.add_property_info(info_dict)
 	ProjectSettings.set_initial_value(name, value)
 
+## Create the toolbar controls for [QodotMap] instances in the editor
 func create_qodot_map_control() -> Control:
 	var separator = VSeparator.new()
 
@@ -121,6 +126,7 @@ func create_qodot_map_control() -> Control:
 
 	return control
 
+## Create a progress bar for building a [QodotMap]
 func create_qodot_map_progress_bar() -> Control:
 	var progress_label = Label.new()
 	progress_label.name = "ProgressLabel"
@@ -142,6 +148,7 @@ func create_qodot_map_progress_bar() -> Control:
 	return progress_bar
 
 
+## Create the "Quick build" button for [QodotMap]s in the editor
 func qodot_map_quick_build() -> void:
 	var edited_object : QodotMap = edited_object_ref.get_ref()
 	if not edited_object:
@@ -157,6 +164,7 @@ func qodot_map_quick_build() -> void:
 
 	edited_object.verify_and_build()
 
+## Create the "Full Build" button for [QodotMap]s in the editor
 func qodot_map_full_build() -> void:
 	var edited_object : QodotMap = edited_object_ref.get_ref()
 	if not edited_object:
@@ -172,6 +180,7 @@ func qodot_map_full_build() -> void:
 
 	edited_object.verify_and_build()
 
+## Create the "Unwrap UV2" button for [QodotMap]s in the editor
 func qodot_map_unwrap_uv2() -> void:
 	var edited_object = edited_object_ref.get_ref()
 	if not edited_object:
@@ -185,6 +194,7 @@ func qodot_map_unwrap_uv2() -> void:
 
 	edited_object.unwrap_uv2()
 
+## Enable or disable the control for [QodotMap]s in the editor
 func set_qodot_map_control_disabled(disabled: bool) -> void:
 	if not qodot_map_control:
 		return
@@ -193,11 +203,13 @@ func set_qodot_map_control_disabled(disabled: bool) -> void:
 		if child is Button:
 			child.set_disabled(disabled)
 
+## Update the build progress bar (see: []) to display the current step and progress (0-1)
 func qodot_map_build_progress(step: String, progress: float) -> void:
 	var progress_label = qodot_map_progress_bar.get_node("ProgressLabel")
 	qodot_map_progress_bar.value = progress
 	progress_label.text = step.capitalize()
 
+## Callback for when the build process for a [QodotMap] is finished.
 func qodot_map_build_complete(qodot_map: QodotMap) -> void:
 	var progress_label = qodot_map_progress_bar.get_node("ProgressLabel")
 	progress_label.text = "Build Complete"

--- a/addons/qodot/src/qodot_plugin.gd
+++ b/addons/qodot/src/qodot_plugin.gd
@@ -85,7 +85,11 @@ func try_add_project_setting(name: String, type: int, value, info: Dictionary = 
 	if not ProjectSettings.has_setting(name):
 		add_project_setting(name, type, value, info)
 
+<<<<<<< HEAD
 ## Add property with path name and type (from [enum @GlobalScript.Variant.Type]) to Project Settings, defaulting to value.
+=======
+## Add property with path name and type from [enum @GlobalScope.Variant.Type] to Project Settings, defaulting to value.
+>>>>>>> 3b52fb3 (Document QodotPlugin)
 ## Optionally, supply property info from info.
 func add_project_setting(name: String, type: int, value, info: Dictionary = {}) -> void:
 	ProjectSettings.set(name, value)
@@ -203,7 +207,11 @@ func set_qodot_map_control_disabled(disabled: bool) -> void:
 		if child is Button:
 			child.set_disabled(disabled)
 
+<<<<<<< HEAD
 ## Update the build progress bar (see: []) to display the current step and progress (0-1)
+=======
+## Update the build progress bar (see: [method create_qodot_map_progress_bar]) to display the current step and progress (0-1)
+>>>>>>> 3b52fb3 (Document QodotPlugin)
 func qodot_map_build_progress(step: String, progress: float) -> void:
 	var progress_label = qodot_map_progress_bar.get_node("ProgressLabel")
 	qodot_map_progress_bar.value = progress

--- a/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
+++ b/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
@@ -3,35 +3,33 @@ class_name QodotFGDSolidClass
 extends QodotFGDClass
 
 enum SpawnType {
-	WORLDSPAWN = 0,
-	MERGE_WORLDSPAWN = 1,
-	ENTITY = 2,
-	GROUP = 3
+	WORLDSPAWN = 0, ## Is worldspawn
+	MERGE_WORLDSPAWN = 1, ## Should be combined with worldspawn
+	ENTITY = 2, ## Is its own separate entity
+	GROUP = 3 ## Is a group
 }
 
 enum CollisionShapeType {
-	NONE,
-	CONVEX,
-	CONCAVE
+	NONE, ## Should have no collision shape
+	CONVEX, ## Should have a convex collision shape
+	CONCAVE ## Should have a concave collision shape
 }
 
-# Controls whether a given SolidClass is the worldspawn, is combined with the worldspawn,
-# or is spawned as its own free-standing entity
 @export var spawn : String = QodotUtil.CATEGORY_STRING
+## Controls whether a given SolidClass is the worldspawn, is combined with the worldspawn, or is spawned as its own free-standing entity
 @export var spawn_type: SpawnType = SpawnType.ENTITY
 
-# Controls how visuals are built for this SolidClass
 @export var visual_build: String = QodotUtil.CATEGORY_STRING
+## Controls whether a visual mesh is built for this SolidClass
 @export var build_visuals := true
 
-# Controls how collisions are built for this SolidClass
 @export var collision_build : String = QodotUtil.CATEGORY_STRING
+## Controls how collisions are built for this SolidClass
 @export var collision_shape_type: CollisionShapeType = CollisionShapeType.CONVEX
 
-# The script file to associate with this SolidClass
-# On building the map, this will be attached to any brush entities created
-# via this classname
 @export var scripting: String = QodotUtil.CATEGORY_STRING
+## The script file to associate with this SolidClass
+## On building the map, this will be attached to any brush entities created via this classname
 @export var script_class: Script
 
 func _init():

--- a/addons/qodot/src/util/qodot_util.gd
+++ b/addons/qodot/src/util/qodot_util.gd
@@ -1,25 +1,33 @@
 class_name QodotUtil
 
-# General-purpose utility functions namespaced to Qodot for compatibility
+## General-purpose utility functions namespaced to Qodot for compatibility
 
+## Print debug messages. True to print, false to ignore
 const DEBUG := true
 
+## String for "category" exports
 const CATEGORY_STRING := '----------------------------------------------------------------'
 
 # Const-predicated print function to avoid excess log spam
+## Print msg if [constant DEBUG] is true
 static func debug_print(msg) -> void:
 	if(DEBUG):
 		print(msg)
 
+## Return a string that corresponds to the current OS's newline control character(s)
 static func newline() -> String:
 	if OS.get_name() == "Windows":
 		return "\r\n"
 	else:
 		return "\n"
 
+## Create a dictionary suitable for creating a category with name when overriding [method Object._get_property_list]
 static func category_dict(name: String) -> Dictionary:
 	return property_dict(name, TYPE_STRING, -1, "", PROPERTY_USAGE_CATEGORY)
 
+## Create a dictionary suitable for overriding [method Object._get_property_list] with
+## Creates a property with name and type from [enum @GlobalScope.Variant.Type]
+## Optionally, provide hint from [enum @GlobalScope.PropertyHint] and corresponding hint_string, and usage from [enum @GlobalScope.PropertyUsageFlags]
 static func property_dict(name: String, type: int, hint: int = -1, hint_string: String = "", usage: int = -1) -> Dictionary:
 	var dict := {
 		'name': name,


### PR DESCRIPTION
This PR contains (hopefully comprehensive) documentation for the exported properties and methods of:
- `QodotPlugin` (no class desc)
- `QodotUtil`
- `QodotEntity`
- `QodotFGDSolidClass` (no class desc)
- `QodotNode3D` (also no class desc (i simply do not know what it does))
- `QodotMap`
In order to create documentation for `QodotMap`, I had to convert the `_get_property_dict()`-based properties to regular exports. See commit 78d2783. In the process, I replaced several old setters dedicated to type checking with explicit typed arrays.