### PR TITLE
Port liquids to Godot 4

### DIFF
--- a/addons/qodot/game_definitions/worldspawn_layers/liquid.gd
+++ b/addons/qodot/game_definitions/worldspawn_layers/liquid.gd
@@ -1,18 +1,19 @@
-class_name LiquidLayer
-extends Area
+class_name LiquidLayer extends Area3D
 
-export(float) var buoyancy_factor = 10.0
-export(float) var lateral_damping_factor = 0.0
-export(float) var vertical_damping_factor = 0.0
+@export var buoyancy_factor: float = 10.0
+@export var lateral_damping_factor: float = 0.0
+@export var vertical_damping_factor: float = 0.0
 
 var buoyancy_dict := {}
 
-func _init() -> void:
-	connect("body_shape_entered", self, "body_shape_entered")
-	connect("body_shape_exited", self, "body_shape_exited")
 
-func body_shape_entered(body_id, body: Node, body_shape_idx: int, self_shape_idx: int) -> void:
-	if not body is RigidBody:
+func _init() -> void:
+	body_shape_entered.connect(_on_body_shape_entered)
+	body_shape_exited.connect(_on_body_shape_exited)
+
+
+func _on_body_shape_entered(body_id, body: Node, body_shape_idx: int, self_shape_idx: int) -> void:
+	if not body is RigidBody3D:
 		return
 
 	var self_collision_shape = shape_owner_get_owner(shape_find_owner(self_shape_idx))
@@ -25,24 +26,25 @@ func body_shape_entered(body_id, body: Node, body_shape_idx: int, self_shape_idx
 	var body_aabb = create_shape_aabb(body_shape)
 
 	buoyancy_dict[body] = {
-		'entry_point': body.global_transform.origin,
-		'self_aabb': self_aabb,
-		'body_aabb': body_aabb
+		"entry_point": body.global_transform.origin, "self_aabb": self_aabb, "body_aabb": body_aabb
 	}
 
-func body_shape_exited(body_id, body: Node, body_shape_idx: int, self_shape_idx: int) -> void:
+
+func _on_body_shape_exited(body_id, body: Node, body_shape_idx: int, self_shape_idx: int) -> void:
 	if body in buoyancy_dict:
 		buoyancy_dict.erase(body)
 
-func create_shape_aabb(shape: Shape) -> AABB:
-	if shape is ConvexPolygonShape:
+
+func create_shape_aabb(shape: Shape3D) -> AABB:
+	if shape is ConvexPolygonShape3D:
 		return create_convex_aabb(shape)
-	elif shape is SphereShape:
+	elif shape is SphereShape3D:
 		return create_sphere_aabb(shape)
 
 	return AABB()
 
-func create_convex_aabb(convex_shape: ConvexPolygonShape) -> AABB:
+
+func create_convex_aabb(convex_shape: ConvexPolygonShape3D) -> AABB:
 	var points = convex_shape.get_points()
 	var aabb = null
 
@@ -54,20 +56,26 @@ func create_convex_aabb(convex_shape: ConvexPolygonShape) -> AABB:
 
 	return aabb
 
-func create_sphere_aabb(sphere_shape: SphereShape) -> AABB:
+
+func create_sphere_aabb(sphere_shape: SphereShape3D) -> AABB:
 	return AABB(-Vector3.ONE * sphere_shape.radius, Vector3.ONE * sphere_shape.radius)
+
 
 func _physics_process(delta: float) -> void:
 	for body in buoyancy_dict:
 		var buoyancy_data = buoyancy_dict[body]
 
-		var self_aabb = buoyancy_data['self_aabb']
+		var self_aabb = buoyancy_data["self_aabb"]
 		self_aabb.position += global_transform.origin
 
-		var body_aabb = buoyancy_data['body_aabb']
+		var body_aabb = buoyancy_data["body_aabb"]
 		body_aabb.position += body.global_transform.origin
 
 		var displacement = self_aabb.end.y - body_aabb.position.y
 		body.add_central_force(Vector3.UP * displacement * buoyancy_factor)
-		body.add_central_force(Vector3(1, 0, 1) * body.get_linear_velocity() * displacement * -lateral_damping_factor)
-		body.add_central_force(Vector3(0, 1, 0) * body.get_linear_velocity() * -vertical_damping_factor)
+		body.add_central_force(
+			Vector3(1, 0, 1) * body.get_linear_velocity() * displacement * -lateral_damping_factor
+		)
+		body.add_central_force(
+			Vector3(0, 1, 0) * body.get_linear_velocity() * -vertical_damping_factor
+		)

--- a/addons/qodot/game_definitions/worldspawn_layers/liquid/lava.gd
+++ b/addons/qodot/game_definitions/worldspawn_layers/liquid/lava.gd
@@ -1,7 +1,7 @@
-class_name LavaLayer
-extends LiquidLayer
+class_name LavaLayer extends LiquidLayer
 
-func _init().() -> void:
+
+func _init() -> void:
 	buoyancy_factor = 6.0
 	vertical_damping_factor = 3.0
 	lateral_damping_factor = 4.0

--- a/addons/qodot/game_definitions/worldspawn_layers/liquid/slime.gd
+++ b/addons/qodot/game_definitions/worldspawn_layers/liquid/slime.gd
@@ -1,7 +1,7 @@
-class_name SlimeLayer
-extends LiquidLayer
+class_name SlimeLayer extends LiquidLayer
 
-func _init().() -> void:
+
+func _init() -> void:
 	buoyancy_factor = 6.0
 	vertical_damping_factor = 3.0
 	lateral_damping_factor = 0.4

--- a/addons/qodot/game_definitions/worldspawn_layers/liquid/water.gd
+++ b/addons/qodot/game_definitions/worldspawn_layers/liquid/water.gd
@@ -1,7 +1,7 @@
-class_name WaterLayer
-extends LiquidLayer
+class_name WaterLayer extends LiquidLayer
 
-func _init().() -> void:
+
+func _init() -> void:
 	buoyancy_factor = 10.0
 	vertical_damping_factor = 3.0
 	lateral_damping_factor = 0.3


### PR DESCRIPTION
Hi there. Reading through the source code of the plugin I've seen that `liquids` weren't properly ported to Godot 4.

I have:
- Updated `export` syntax
- Updated how signals are connected
- s/RigidBody/RigidBody3D
- s/SphereShape/SphereShape3D
- s/ConvexPolygonShape/ConvexPolygonShape3D
- Removed invalid `_init().()` syntax

PD: I've run the gdformatter and has created many changes, I can revert them if you prefer.