### PR TITLE
Remove `get_class` method override

### DIFF
--- a/addons/qodot/src/nodes/qodot_entity.gd
+++ b/addons/qodot/src/nodes/qodot_entity.gd
@@ -1,5 +1,4 @@
-class_name QodotEntity
-extends QodotNode3D
+class_name QodotEntity extends QodotNode3D
 
 ## Base class for entities created by Qodot
 ##
@@ -9,17 +8,15 @@ extends QodotNode3D
 ## @tutorial: https://qodotplugin.github.io/docs/entities/scripting-entities
 
 ## Properties for this entity. Populated from Trenchbroom's entity property editor when building a [QodotMap].
-@export var properties: Dictionary :
+@export var properties: Dictionary:
 	get:
-		return properties # TODOConverter40 Non existent get function 
+		return properties  # TODO Converter40 Non existent get function
 	set(new_properties):
-		if(properties != new_properties):
+		if properties != new_properties:
 			properties = new_properties
 			update_properties()
+
 
 ## Handle updates to [member properties]
 func update_properties() -> void:
 	pass
-
-func get_class() -> String:
-	return 'QodotEntity'

--- a/addons/qodot/src/nodes/qodot_node3d.gd
+++ b/addons/qodot/src/nodes/qodot_node3d.gd
@@ -1,7 +1,2 @@
-@icon('res://addons/qodot/icons/icon_qodot_node3d.svg')
-class_name QodotNode3D
-extends Node3D
-
-## Unused internal function
-func get_class() -> String:
-	return 'QodotSpatial'
+@icon("res://addons/qodot/icons/icon_qodot_node3d.svg")
+class_name QodotNode3D extends Node3D


### PR DESCRIPTION
:wave: Having a look at https://github.com/QodotPlugin/Qodot/issues/44 I've seen that in `QodotEntity` and `QodotNode3D` the native method `get_class` is overrided, however that is not possible anymore in Godot 4.

This isn't a problem if users have disabled in their project settings to raise errors in addons but if they have them enabled Qodot won't work.

Even with errors in addons disabled this method shouldn't be doing anything (because is not allowed) and I didn't find any usage of it, so I have removed it altogether.