### PR TITLE
Re-save resources

### DIFF
--- a/addons/qodot/game_definitions/brush_tags/trigger_tag.tres
+++ b/addons/qodot/game_definitions/brush_tags/trigger_tag.tres
@@ -1,11 +1,11 @@
-[gd_resource type="Resource" load_steps=2 format=2]
+[gd_resource type="Resource" script_class="TrenchBroomTag" load_steps=2 format=3 uid="uid://bd23tengu5m5u"]
 
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/trenchbroom/trenchbroom_tag.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/trenchbroom/trenchbroom_tag.gd" id="1"]
 
 [resource]
-script = ExtResource( 1 )
+script = ExtResource("1")
 tag_name = "Trigger"
-tag_attributes = [ "transparent" ]
+tag_attributes = Array[String](["transparent"])
 tag_match_type = 4
 tag_pattern = "trigger*"
 texture_name = "trigger"

--- a/addons/qodot/game_definitions/face_tags/skip_tag.tres
+++ b/addons/qodot/game_definitions/face_tags/skip_tag.tres
@@ -1,11 +1,11 @@
-[gd_resource type="Resource" load_steps=2 format=2]
+[gd_resource type="Resource" script_class="TrenchBroomTag" load_steps=2 format=3 uid="uid://b3ec6041xnoec"]
 
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/trenchbroom/trenchbroom_tag.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/trenchbroom/trenchbroom_tag.gd" id="1"]
 
 [resource]
-script = ExtResource( 1 )
+script = ExtResource("1")
 tag_name = "Skip"
-tag_attributes = [ "transparent" ]
+tag_attributes = Array[String](["transparent"])
 tag_match_type = 0
 tag_pattern = "skip"
 texture_name = ""

--- a/addons/qodot/game_definitions/fgd/base_classes/light_base_class.tres
+++ b/addons/qodot/game_definitions/fgd/base_classes/light_base_class.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://c5o31v30rw7v5"]
+[gd_resource type="Resource" script_class="QodotFGDBaseClass" load_steps=2 format=3 uid="uid://c5o31v30rw7v5"]
 
 [ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_base_class.gd" id="1"]
 
@@ -8,7 +8,7 @@ class_options = "---------------------------------------------------------------
 classname = "Light"
 description = ""
 qodot_internal = false
-base_classes = []
+base_classes = Array[Resource]([])
 class_properties = {
 "_color": Color(1, 1, 1, 1),
 "delay": {

--- a/addons/qodot/game_definitions/fgd/base_classes/target_base_class.tres
+++ b/addons/qodot/game_definitions/fgd/base_classes/target_base_class.tres
@@ -1,23 +1,17 @@
-[gd_resource type="Resource" load_steps=2 format=2]
+[gd_resource type="Resource" script_class="QodotFGDBaseClass" load_steps=2 format=3 uid="uid://dgm276g7bw8q5"]
 
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_base_class.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_base_class.gd" id="1"]
 
 [resource]
-script = ExtResource( 1 )
+script = ExtResource("1")
 class_options = "----------------------------------------------------------------"
 classname = "Target"
 description = ""
 qodot_internal = false
-base_classes = [  ]
-class_properties = {
-
-}
-class_property_descriptions = {
-
-}
-meta_properties = {
-
-}
+base_classes = Array[Resource]([])
+class_properties = {}
+class_property_descriptions = {}
+meta_properties = {}
 node_options = "----------------------------------------------------------------"
 node_class = ""
 transient_node = false

--- a/addons/qodot/game_definitions/fgd/base_classes/targetname_base_class.tres
+++ b/addons/qodot/game_definitions/fgd/base_classes/targetname_base_class.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://ccdjpf5j25aua"]
+[gd_resource type="Resource" script_class="QodotFGDBaseClass" load_steps=2 format=3 uid="uid://ccdjpf5j25aua"]
 
 [ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_base_class.gd" id="1"]
 
@@ -8,7 +8,7 @@ class_options = "---------------------------------------------------------------
 classname = "Targetname"
 description = ""
 qodot_internal = false
-base_classes = []
+base_classes = Array[Resource]([])
 class_properties = {
 "targetname": null
 }

--- a/addons/qodot/game_definitions/fgd/point_classes/light_point_class.tres
+++ b/addons/qodot/game_definitions/fgd/point_classes/light_point_class.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" load_steps=4 format=3 uid="uid://ccwosedfa8v8d"]
+[gd_resource type="Resource" script_class="QodotFGDPointClass" load_steps=4 format=3 uid="uid://ccwosedfa8v8d"]
 
 [ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_point_class.gd" id="1"]
 [ext_resource type="Script" path="res://addons/qodot/game_definitions/fgd/point_classes/light.gd" id="2"]
@@ -13,7 +13,7 @@ class_options = "---------------------------------------------------------------
 classname = "light"
 description = "Invisible light source"
 qodot_internal = false
-base_classes = [ExtResource("3")]
+base_classes = Array[Resource]([ExtResource("3")])
 class_properties = {
 "angle": 0.0
 }

--- a/addons/qodot/game_definitions/fgd/point_classes/physics_ball_point_class.tres
+++ b/addons/qodot/game_definitions/fgd/point_classes/physics_ball_point_class.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" load_steps=4 format=3 uid="uid://cubvqwi3p77sq"]
+[gd_resource type="Resource" script_class="QodotFGDPointClass" load_steps=4 format=3 uid="uid://cubvqwi3p77sq"]
 
 [ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_point_class.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://b7ccfkajnmn64" path="res://addons/qodot/game_definitions/fgd/point_classes/physics_ball.tscn" id="2"]
@@ -14,7 +14,7 @@ class_options = "---------------------------------------------------------------
 classname = "physics_ball"
 description = "Physics Ball"
 qodot_internal = false
-base_classes = []
+base_classes = Array[Resource]([])
 class_properties = {
 "mass": 1.0,
 "size": 1.0,

--- a/addons/qodot/game_definitions/fgd/point_classes/receiver_point_class.tres
+++ b/addons/qodot/game_definitions/fgd/point_classes/receiver_point_class.tres
@@ -1,18 +1,18 @@
-[gd_resource type="Resource" load_steps=4 format=2]
+[gd_resource type="Resource" script_class="QodotFGDPointClass" load_steps=4 format=3 uid="uid://dbh35xj5q8gvc"]
 
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_point_class.gd" type="Script" id=1]
-[ext_resource path="res://addons/qodot/game_definitions/fgd/base_classes/target_base_class.tres" type="Resource" id=2]
-[ext_resource path="res://addons/qodot/game_definitions/fgd/base_classes/targetname_base_class.tres" type="Resource" id=3]
-
-
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_point_class.gd" id="1"]
+[ext_resource type="Resource" uid="uid://dgm276g7bw8q5" path="res://addons/qodot/game_definitions/fgd/base_classes/target_base_class.tres" id="2"]
+[ext_resource type="Resource" uid="uid://ccdjpf5j25aua" path="res://addons/qodot/game_definitions/fgd/base_classes/targetname_base_class.tres" id="3"]
 
 [resource]
-script = ExtResource( 1 )
+script = ExtResource("1")
+scene = "----------------------------------------------------------------"
+scripting = "----------------------------------------------------------------"
 class_options = "----------------------------------------------------------------"
 classname = "receiver"
 description = "Receiver"
 qodot_internal = false
-base_classes = [ ExtResource( 3 ), ExtResource( 2 ) ]
+base_classes = Array[Resource]([ExtResource("3"), ExtResource("2")])
 class_properties = {
 "receiver_name": ""
 }
@@ -20,10 +20,8 @@ class_property_descriptions = {
 "slot_name": "Receiver method to target"
 }
 meta_properties = {
-"size": AABB( -8, -8, -8, 8, 8, 8 )
+"size": AABB(-8, -8, -8, 8, 8, 8)
 }
 node_options = "----------------------------------------------------------------"
 node_class = ""
 transient_node = true
-scene = "----------------------------------------------------------------"
-scripting = "----------------------------------------------------------------"

--- a/addons/qodot/game_definitions/fgd/point_classes/signal_point_class.tres
+++ b/addons/qodot/game_definitions/fgd/point_classes/signal_point_class.tres
@@ -1,16 +1,18 @@
-[gd_resource type="Resource" load_steps=4 format=2]
+[gd_resource type="Resource" script_class="QodotFGDPointClass" load_steps=4 format=3 uid="uid://bu3h1cvdigp1i"]
 
-[ext_resource path="res://addons/qodot/game_definitions/fgd/base_classes/target_base_class.tres" type="Resource" id=1]
-[ext_resource path="res://addons/qodot/game_definitions/fgd/base_classes/targetname_base_class.tres" type="Resource" id=2]
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_point_class.gd" type="Script" id=3]
+[ext_resource type="Resource" uid="uid://dgm276g7bw8q5" path="res://addons/qodot/game_definitions/fgd/base_classes/target_base_class.tres" id="1"]
+[ext_resource type="Resource" uid="uid://ccdjpf5j25aua" path="res://addons/qodot/game_definitions/fgd/base_classes/targetname_base_class.tres" id="2"]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_point_class.gd" id="3"]
 
 [resource]
-script = ExtResource( 3 )
+script = ExtResource("3")
+scene = "----------------------------------------------------------------"
+scripting = "----------------------------------------------------------------"
 class_options = "----------------------------------------------------------------"
 classname = "signal"
 description = "Signal"
 qodot_internal = false
-base_classes = [ ExtResource( 2 ), ExtResource( 1 ) ]
+base_classes = Array[Resource]([ExtResource("2"), ExtResource("1")])
 class_properties = {
 "signal_name": ""
 }
@@ -18,10 +20,8 @@ class_property_descriptions = {
 "signal_name": "Signal to target"
 }
 meta_properties = {
-"size": AABB( -8, -8, -8, 8, 8, 8 )
+"size": AABB(-8, -8, -8, 8, 8, 8)
 }
 node_options = "----------------------------------------------------------------"
 node_class = ""
 transient_node = true
-scene = "----------------------------------------------------------------"
-scripting = "----------------------------------------------------------------"

--- a/addons/qodot/game_definitions/fgd/qodot_fgd.tres
+++ b/addons/qodot/game_definitions/fgd/qodot_fgd.tres
@@ -1,29 +1,29 @@
 [gd_resource type="Resource" script_class="QodotFGDFile" load_steps=20 format=3 uid="uid://7h57nuq1xmoi"]
 
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/fgd/base_classes/target_base_class.tres" id="1"]
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/fgd/solid_classes/func_group_solid_class.tres" id="2"]
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/fgd/point_classes/signal_point_class.tres" id="3"]
+[ext_resource type="Resource" uid="uid://dgm276g7bw8q5" path="res://addons/qodot/game_definitions/fgd/base_classes/target_base_class.tres" id="1"]
+[ext_resource type="Resource" uid="uid://cw4s1hnxqetee" path="res://addons/qodot/game_definitions/fgd/solid_classes/func_group_solid_class.tres" id="2"]
+[ext_resource type="Resource" uid="uid://bu3h1cvdigp1i" path="res://addons/qodot/game_definitions/fgd/point_classes/signal_point_class.tres" id="3"]
 [ext_resource type="Resource" uid="uid://ccdjpf5j25aua" path="res://addons/qodot/game_definitions/fgd/base_classes/targetname_base_class.tres" id="4"]
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/fgd/solid_classes/trigger_solid_class.tres" id="5"]
+[ext_resource type="Resource" uid="uid://b70dbh5v15xno" path="res://addons/qodot/game_definitions/fgd/solid_classes/trigger_solid_class.tres" id="5"]
 [ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_file.gd" id="6"]
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/fgd/point_classes/receiver_point_class.tres" id="7"]
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/fgd/solid_classes/illusionary_solid_class.tres" id="8"]
+[ext_resource type="Resource" uid="uid://dbh35xj5q8gvc" path="res://addons/qodot/game_definitions/fgd/point_classes/receiver_point_class.tres" id="7"]
+[ext_resource type="Resource" uid="uid://dy7undvxjvodx" path="res://addons/qodot/game_definitions/fgd/solid_classes/illusionary_solid_class.tres" id="8"]
 [ext_resource type="Resource" uid="uid://dxp37dladbquv" path="res://addons/qodot/game_definitions/fgd/solid_classes/worldspawn_solid_class.tres" id="9"]
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/fgd/solid_classes/group_solid_class.tres" id="10"]
+[ext_resource type="Resource" uid="uid://bnbdy0cky2bo" path="res://addons/qodot/game_definitions/fgd/solid_classes/group_solid_class.tres" id="10"]
 [ext_resource type="Resource" uid="uid://b8aisardk4k4u" path="res://addons/qodot/game_definitions/fgd/solid_classes/detail_solid_class.tres" id="11"]
 [ext_resource type="Resource" uid="uid://c5o31v30rw7v5" path="res://addons/qodot/game_definitions/fgd/base_classes/light_base_class.tres" id="12"]
 [ext_resource type="Resource" uid="uid://ccwosedfa8v8d" path="res://addons/qodot/game_definitions/fgd/point_classes/light_point_class.tres" id="13"]
 [ext_resource type="Resource" uid="uid://de6w02sa4ckl5" path="res://addons/qodot/game_definitions/fgd/solid_classes/rotate_solid_class.tres" id="14"]
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/fgd/solid_classes/button_solid_class.tres" id="15"]
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/fgd/solid_classes/physics_solid_class.tres" id="16"]
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/fgd/solid_classes/wall_solid_class.tres" id="17"]
+[ext_resource type="Resource" uid="uid://ckg61cpr5p63l" path="res://addons/qodot/game_definitions/fgd/solid_classes/button_solid_class.tres" id="15"]
+[ext_resource type="Resource" uid="uid://v3fbh0xn5d2h" path="res://addons/qodot/game_definitions/fgd/solid_classes/physics_solid_class.tres" id="16"]
+[ext_resource type="Resource" uid="uid://bu2f3lupsjhfp" path="res://addons/qodot/game_definitions/fgd/solid_classes/wall_solid_class.tres" id="17"]
 [ext_resource type="Resource" uid="uid://cubvqwi3p77sq" path="res://addons/qodot/game_definitions/fgd/point_classes/physics_ball_point_class.tres" id="18"]
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/fgd/solid_classes/mover_solid_class.tres" id="19"]
+[ext_resource type="Resource" uid="uid://b3yn012fy6782" path="res://addons/qodot/game_definitions/fgd/solid_classes/mover_solid_class.tres" id="19"]
 
 [resource]
 script = ExtResource("6")
 export_file = false
-target_folder = "C:/OtherPrograms/TrenchBroom/games/Qodot"
+target_folder = ""
 fgd_name = "Qodot"
 base_fgd_files = Array[Resource]([])
 entity_definitions = Array[Resource]([ExtResource("9"), ExtResource("1"), ExtResource("4"), ExtResource("12"), ExtResource("3"), ExtResource("13"), ExtResource("7"), ExtResource("18"), ExtResource("2"), ExtResource("10"), ExtResource("11"), ExtResource("8"), ExtResource("17"), ExtResource("5"), ExtResource("14"), ExtResource("19"), ExtResource("16"), ExtResource("15")])

--- a/addons/qodot/game_definitions/fgd/solid_classes/button_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/button_solid_class.tres
@@ -1,31 +1,10 @@
-[gd_resource type="Resource" load_steps=3 format=2]
+[gd_resource type="Resource" script_class="QodotFGDSolidClass" load_steps=3 format=3 uid="uid://ckg61cpr5p63l"]
 
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" type="Script" id=1]
-[ext_resource path="res://addons/qodot/game_definitions/fgd/solid_classes/button.gd" type="Script" id=2]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" id="1"]
+[ext_resource type="Script" path="res://addons/qodot/game_definitions/fgd/solid_classes/button.gd" id="2"]
 
 [resource]
-script = ExtResource( 1 )
-class_options = "----------------------------------------------------------------"
-classname = "button"
-description = "Interactive button brush."
-qodot_internal = false
-base_classes = [  ]
-class_properties = {
-"axis": Vector3( 0, -1, 0 ),
-"depth": 0.8,
-"press_signal_delay": 0.0,
-"release_delay": 0.0,
-"release_signal_delay": 0.0,
-"speed": 8.0,
-"trigger_signal_delay": 0.0
-}
-class_property_descriptions = {
-}
-meta_properties = {
-}
-node_options = "----------------------------------------------------------------"
-node_class = "Area"
-transient_node = false
+script = ExtResource("1")
 spawn = "----------------------------------------------------------------"
 spawn_type = 2
 visual_build = "----------------------------------------------------------------"
@@ -33,4 +12,23 @@ build_visuals = true
 collision_build = "----------------------------------------------------------------"
 collision_shape_type = 1
 scripting = "----------------------------------------------------------------"
-script_class = ExtResource( 2 )
+script_class = ExtResource("2")
+class_options = "----------------------------------------------------------------"
+classname = "button"
+description = "Interactive button brush."
+qodot_internal = false
+base_classes = Array[Resource]([])
+class_properties = {
+"axis": Vector3(0, -1, 0),
+"depth": 0.8,
+"press_signal_delay": 0.0,
+"release_delay": 0.0,
+"release_signal_delay": 0.0,
+"speed": 8.0,
+"trigger_signal_delay": 0.0
+}
+class_property_descriptions = {}
+meta_properties = {}
+node_options = "----------------------------------------------------------------"
+node_class = "Area"
+transient_node = false

--- a/addons/qodot/game_definitions/fgd/solid_classes/detail_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/detail_solid_class.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://b8aisardk4k4u"]
+[gd_resource type="Resource" script_class="QodotFGDSolidClass" load_steps=2 format=3 uid="uid://b8aisardk4k4u"]
 
 [ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" id="1"]
 
@@ -15,7 +15,7 @@ class_options = "---------------------------------------------------------------
 classname = "detail"
 description = "Detail Brush"
 qodot_internal = false
-base_classes = []
+base_classes = Array[Resource]([])
 class_properties = {}
 class_property_descriptions = {}
 meta_properties = {}

--- a/addons/qodot/game_definitions/fgd/solid_classes/func_group_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/func_group_solid_class.tres
@@ -1,26 +1,9 @@
-[gd_resource type="Resource" load_steps=2 format=2]
+[gd_resource type="Resource" script_class="QodotFGDSolidClass" load_steps=2 format=3 uid="uid://cw4s1hnxqetee"]
 
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" id="1"]
 
 [resource]
-script = ExtResource( 1 )
-class_options = "----------------------------------------------------------------"
-classname = "func_group"
-description = "TrenchBroom Group"
-qodot_internal = true
-base_classes = [  ]
-class_properties = {
-
-}
-class_property_descriptions = {
-
-}
-meta_properties = {
-
-}
-node_options = "----------------------------------------------------------------"
-node_class = "StaticBody"
-transient_node = false
+script = ExtResource("1")
 spawn = "----------------------------------------------------------------"
 spawn_type = 3
 visual_build = "----------------------------------------------------------------"
@@ -28,3 +11,14 @@ build_visuals = true
 collision_build = "----------------------------------------------------------------"
 collision_shape_type = 1
 scripting = "----------------------------------------------------------------"
+class_options = "----------------------------------------------------------------"
+classname = "func_group"
+description = "TrenchBroom Group"
+qodot_internal = true
+base_classes = Array[Resource]([])
+class_properties = {}
+class_property_descriptions = {}
+meta_properties = {}
+node_options = "----------------------------------------------------------------"
+node_class = "StaticBody"
+transient_node = false

--- a/addons/qodot/game_definitions/fgd/solid_classes/group_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/group_solid_class.tres
@@ -1,26 +1,9 @@
-[gd_resource type="Resource" load_steps=2 format=2]
+[gd_resource type="Resource" script_class="QodotFGDSolidClass" load_steps=2 format=3 uid="uid://bnbdy0cky2bo"]
 
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" id="1"]
 
 [resource]
-script = ExtResource( 1 )
-class_options = "----------------------------------------------------------------"
-classname = "group"
-description = "Brush Group"
-qodot_internal = false
-base_classes = [  ]
-class_properties = {
-
-}
-class_property_descriptions = {
-
-}
-meta_properties = {
-
-}
-node_options = "----------------------------------------------------------------"
-node_class = "StaticBody"
-transient_node = false
+script = ExtResource("1")
 spawn = "----------------------------------------------------------------"
 spawn_type = 1
 visual_build = "----------------------------------------------------------------"
@@ -28,3 +11,14 @@ build_visuals = true
 collision_build = "----------------------------------------------------------------"
 collision_shape_type = 1
 scripting = "----------------------------------------------------------------"
+class_options = "----------------------------------------------------------------"
+classname = "group"
+description = "Brush Group"
+qodot_internal = false
+base_classes = Array[Resource]([])
+class_properties = {}
+class_property_descriptions = {}
+meta_properties = {}
+node_options = "----------------------------------------------------------------"
+node_class = "StaticBody"
+transient_node = false

--- a/addons/qodot/game_definitions/fgd/solid_classes/illusionary_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/illusionary_solid_class.tres
@@ -1,26 +1,9 @@
-[gd_resource type="Resource" load_steps=2 format=2]
+[gd_resource type="Resource" script_class="QodotFGDSolidClass" load_steps=2 format=3 uid="uid://dy7undvxjvodx"]
 
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" id="1"]
 
 [resource]
-script = ExtResource( 1 )
-class_options = "----------------------------------------------------------------"
-classname = "illusionary"
-description = "Non-colliding Brush"
-qodot_internal = false
-base_classes = [  ]
-class_properties = {
-
-}
-class_property_descriptions = {
-
-}
-meta_properties = {
-
-}
-node_options = "----------------------------------------------------------------"
-node_class = "Spatial"
-transient_node = false
+script = ExtResource("1")
 spawn = "----------------------------------------------------------------"
 spawn_type = 1
 visual_build = "----------------------------------------------------------------"
@@ -28,3 +11,14 @@ build_visuals = true
 collision_build = "----------------------------------------------------------------"
 collision_shape_type = 0
 scripting = "----------------------------------------------------------------"
+class_options = "----------------------------------------------------------------"
+classname = "illusionary"
+description = "Non-colliding Brush"
+qodot_internal = false
+base_classes = Array[Resource]([])
+class_properties = {}
+class_property_descriptions = {}
+meta_properties = {}
+node_options = "----------------------------------------------------------------"
+node_class = "Spatial"
+transient_node = false

--- a/addons/qodot/game_definitions/fgd/solid_classes/mover_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/mover_solid_class.tres
@@ -1,28 +1,10 @@
-[gd_resource type="Resource" load_steps=3 format=2]
+[gd_resource type="Resource" script_class="QodotFGDSolidClass" load_steps=3 format=3 uid="uid://b3yn012fy6782"]
 
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" type="Script" id=1]
-[ext_resource path="res://addons/qodot/game_definitions/fgd/solid_classes/mover.gd" type="Script" id=2]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" id="1"]
+[ext_resource type="Script" path="res://addons/qodot/game_definitions/fgd/solid_classes/mover.gd" id="2"]
 
 [resource]
-script = ExtResource( 1 )
-class_options = "----------------------------------------------------------------"
-classname = "mover"
-description = "Moving brush."
-qodot_internal = false
-base_classes = [  ]
-class_properties = {
-"rotation": Vector3( 0, 0, 0 ),
-"scale": Vector3( 1, 1, 1 ),
-"speed": 1.0,
-"translation": Vector3( 0, 0, 0 )
-}
-class_property_descriptions = {
-}
-meta_properties = {
-}
-node_options = "----------------------------------------------------------------"
-node_class = "KinematicBody"
-transient_node = false
+script = ExtResource("1")
 spawn = "----------------------------------------------------------------"
 spawn_type = 2
 visual_build = "----------------------------------------------------------------"
@@ -30,4 +12,20 @@ build_visuals = true
 collision_build = "----------------------------------------------------------------"
 collision_shape_type = 1
 scripting = "----------------------------------------------------------------"
-script_class = ExtResource( 2 )
+script_class = ExtResource("2")
+class_options = "----------------------------------------------------------------"
+classname = "mover"
+description = "Moving brush."
+qodot_internal = false
+base_classes = Array[Resource]([])
+class_properties = {
+"rotation": Vector3(0, 0, 0),
+"scale": Vector3(1, 1, 1),
+"speed": 1.0,
+"translation": Vector3(0, 0, 0)
+}
+class_property_descriptions = {}
+meta_properties = {}
+node_options = "----------------------------------------------------------------"
+node_class = "KinematicBody"
+transient_node = false

--- a/addons/qodot/game_definitions/fgd/solid_classes/physics_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/physics_solid_class.tres
@@ -1,26 +1,10 @@
-[gd_resource type="Resource" load_steps=3 format=2]
+[gd_resource type="Resource" script_class="QodotFGDSolidClass" load_steps=3 format=3 uid="uid://v3fbh0xn5d2h"]
 
-[ext_resource path="res://addons/qodot/game_definitions/fgd/solid_classes/physics.gd" type="Script" id=1]
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" type="Script" id=2]
+[ext_resource type="Script" path="res://addons/qodot/game_definitions/fgd/solid_classes/physics.gd" id="1"]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" id="2"]
 
 [resource]
-script = ExtResource( 2 )
-class_options = "----------------------------------------------------------------"
-classname = "physics"
-description = "Physics Brush"
-qodot_internal = false
-base_classes = [  ]
-class_properties = {
-"mass": 1.0,
-"velocity": Vector3( 0, 0, 0 )
-}
-class_property_descriptions = {
-}
-meta_properties = {
-}
-node_options = "----------------------------------------------------------------"
-node_class = "RigidBody"
-transient_node = false
+script = ExtResource("2")
 spawn = "----------------------------------------------------------------"
 spawn_type = 2
 visual_build = "----------------------------------------------------------------"
@@ -28,4 +12,18 @@ build_visuals = true
 collision_build = "----------------------------------------------------------------"
 collision_shape_type = 1
 scripting = "----------------------------------------------------------------"
-script_class = ExtResource( 1 )
+script_class = ExtResource("1")
+class_options = "----------------------------------------------------------------"
+classname = "physics"
+description = "Physics Brush"
+qodot_internal = false
+base_classes = Array[Resource]([])
+class_properties = {
+"mass": 1.0,
+"velocity": Vector3(0, 0, 0)
+}
+class_property_descriptions = {}
+meta_properties = {}
+node_options = "----------------------------------------------------------------"
+node_class = "RigidBody"
+transient_node = false

--- a/addons/qodot/game_definitions/fgd/solid_classes/rotate_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/rotate_solid_class.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" load_steps=3 format=3 uid="uid://de6w02sa4ckl5"]
+[gd_resource type="Resource" script_class="QodotFGDSolidClass" load_steps=3 format=3 uid="uid://de6w02sa4ckl5"]
 
 [ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" id="1"]
 [ext_resource type="Script" path="res://addons/qodot/game_definitions/fgd/solid_classes/rotate.gd" id="2_kxqod"]
@@ -17,7 +17,7 @@ class_options = "---------------------------------------------------------------
 classname = "rotate"
 description = "Rotating Brush"
 qodot_internal = false
-base_classes = []
+base_classes = Array[Resource]([])
 class_properties = {
 "axis": Vector3(0, 1, 0),
 "speed": 360.0

--- a/addons/qodot/game_definitions/fgd/solid_classes/trigger_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/trigger_solid_class.tres
@@ -1,28 +1,10 @@
-[gd_resource type="Resource" load_steps=3 format=2]
+[gd_resource type="Resource" script_class="QodotFGDSolidClass" load_steps=3 format=3 uid="uid://b70dbh5v15xno"]
 
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" type="Script" id=1]
-[ext_resource path="res://addons/qodot/game_definitions/fgd/solid_classes/trigger.gd" type="Script" id=2]
-
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" id="1"]
+[ext_resource type="Script" path="res://addons/qodot/game_definitions/fgd/solid_classes/trigger.gd" id="2"]
 
 [resource]
-script = ExtResource( 1 )
-class_options = "----------------------------------------------------------------"
-classname = "trigger"
-description = "Trigger Volume"
-qodot_internal = false
-base_classes = [  ]
-class_properties = {
-
-}
-class_property_descriptions = {
-
-}
-meta_properties = {
-
-}
-node_options = "----------------------------------------------------------------"
-node_class = "Area"
-transient_node = false
+script = ExtResource("1")
 spawn = "----------------------------------------------------------------"
 spawn_type = 2
 visual_build = "----------------------------------------------------------------"
@@ -30,4 +12,15 @@ build_visuals = false
 collision_build = "----------------------------------------------------------------"
 collision_shape_type = 1
 scripting = "----------------------------------------------------------------"
-script_class = ExtResource( 2 )
+script_class = ExtResource("2")
+class_options = "----------------------------------------------------------------"
+classname = "trigger"
+description = "Trigger Volume"
+qodot_internal = false
+base_classes = Array[Resource]([])
+class_properties = {}
+class_property_descriptions = {}
+meta_properties = {}
+node_options = "----------------------------------------------------------------"
+node_class = "Area"
+transient_node = false

--- a/addons/qodot/game_definitions/fgd/solid_classes/wall_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/wall_solid_class.tres
@@ -1,26 +1,9 @@
-[gd_resource type="Resource" load_steps=2 format=2]
+[gd_resource type="Resource" script_class="QodotFGDSolidClass" load_steps=2 format=3 uid="uid://bu2f3lupsjhfp"]
 
-[ext_resource path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" id="1"]
 
 [resource]
-script = ExtResource( 1 )
-class_options = "----------------------------------------------------------------"
-classname = "wall"
-description = "Basic entity brush."
-qodot_internal = false
-base_classes = [  ]
-class_properties = {
-
-}
-class_property_descriptions = {
-
-}
-meta_properties = {
-
-}
-node_options = "----------------------------------------------------------------"
-node_class = "StaticBody"
-transient_node = false
+script = ExtResource("1")
 spawn = "----------------------------------------------------------------"
 spawn_type = 2
 visual_build = "----------------------------------------------------------------"
@@ -28,3 +11,14 @@ build_visuals = true
 collision_build = "----------------------------------------------------------------"
 collision_shape_type = 1
 scripting = "----------------------------------------------------------------"
+class_options = "----------------------------------------------------------------"
+classname = "wall"
+description = "Basic entity brush."
+qodot_internal = false
+base_classes = Array[Resource]([])
+class_properties = {}
+class_property_descriptions = {}
+meta_properties = {}
+node_options = "----------------------------------------------------------------"
+node_class = "StaticBody"
+transient_node = false

--- a/addons/qodot/game_definitions/fgd/solid_classes/worldspawn_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/worldspawn_solid_class.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://dxp37dladbquv"]
+[gd_resource type="Resource" script_class="QodotFGDSolidClass" load_steps=2 format=3 uid="uid://dxp37dladbquv"]
 
 [ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd" id="1"]
 
@@ -15,7 +15,7 @@ class_options = "---------------------------------------------------------------
 classname = "worldspawn"
 description = "World Entity"
 qodot_internal = false
-base_classes = []
+base_classes = Array[Resource]([])
 class_properties = {}
 class_property_descriptions = {}
 meta_properties = {}

--- a/addons/qodot/game_definitions/trenchbroom_game_config.tres
+++ b/addons/qodot/game_definitions/trenchbroom_game_config.tres
@@ -3,10 +3,10 @@
 [ext_resource type="Resource" path="res://addons/qodot/game_definitions/brush_tags/detail_tag.tres" id="1_bjrlk"]
 [ext_resource type="Resource" uid="uid://7h57nuq1xmoi" path="res://addons/qodot/game_definitions/fgd/qodot_fgd.tres" id="1_y22p1"]
 [ext_resource type="Texture2D" uid="uid://b2k2iutnsgjfy" path="res://addons/qodot/icon.png" id="2_jej4n"]
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/brush_tags/trigger_tag.tres" id="2_kk04y"]
+[ext_resource type="Resource" uid="uid://bd23tengu5m5u" path="res://addons/qodot/game_definitions/brush_tags/trigger_tag.tres" id="2_kk04y"]
 [ext_resource type="Script" path="res://addons/qodot/src/resources/game-definitions/trenchbroom_game_config.gd" id="3_8vw40"]
 [ext_resource type="Resource" uid="uid://dpjjh0hst6xj" path="res://addons/qodot/game_definitions/face_tags/clip_tag.tres" id="3_hren3"]
-[ext_resource type="Resource" path="res://addons/qodot/game_definitions/face_tags/skip_tag.tres" id="4_y3jqb"]
+[ext_resource type="Resource" uid="uid://b3ec6041xnoec" path="res://addons/qodot/game_definitions/face_tags/skip_tag.tres" id="4_y3jqb"]
 
 [resource]
 script = ExtResource("3_8vw40")

--- a/addons/qodot/game_definitions/worldspawn_layers/liquid/lava.tres
+++ b/addons/qodot/game_definitions/worldspawn_layers/liquid/lava.tres
@@ -1,14 +1,14 @@
-[gd_resource type="Resource" load_steps=3 format=2]
+[gd_resource type="Resource" script_class="QodotWorldspawnLayer" load_steps=3 format=3 uid="uid://clidbhxth4icl"]
 
-[ext_resource path="res://addons/qodot/src/resources/worldspawn_layer.gd" type="Script" id=1]
-[ext_resource path="res://addons/qodot/game_definitions/worldspawn_layers/liquid/lava.gd" type="Script" id=2]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/worldspawn_layer.gd" id="1"]
+[ext_resource type="Script" path="res://addons/qodot/game_definitions/worldspawn_layers/liquid/lava.gd" id="2"]
 
 [resource]
 resource_name = "Lava Layer"
-script = ExtResource( 1 )
+script = ExtResource("1")
 name = "lava"
 texture = "layers/lava"
 node_class = "Area"
 build_visuals = true
 collision_shape_type = 1
-script_class = ExtResource( 2 )
+script_class = ExtResource("2")

--- a/addons/qodot/game_definitions/worldspawn_layers/liquid/slime.tres
+++ b/addons/qodot/game_definitions/worldspawn_layers/liquid/slime.tres
@@ -1,14 +1,14 @@
-[gd_resource type="Resource" load_steps=3 format=2]
+[gd_resource type="Resource" script_class="QodotWorldspawnLayer" load_steps=3 format=3 uid="uid://b2f6ok8hsauat"]
 
-[ext_resource path="res://addons/qodot/src/resources/worldspawn_layer.gd" type="Script" id=1]
-[ext_resource path="res://addons/qodot/game_definitions/worldspawn_layers/liquid/slime.gd" type="Script" id=2]
+[ext_resource type="Script" path="res://addons/qodot/src/resources/worldspawn_layer.gd" id="1"]
+[ext_resource type="Script" path="res://addons/qodot/game_definitions/worldspawn_layers/liquid/slime.gd" id="2"]
 
 [resource]
 resource_name = "Slime Layer"
-script = ExtResource( 1 )
+script = ExtResource("1")
 name = "slime"
 texture = "layers/slime"
 node_class = "Area"
 build_visuals = true
 collision_shape_type = 1
-script_class = ExtResource( 2 )
+script_class = ExtResource("2")

--- a/addons/qodot/game_definitions/worldspawn_layers/liquid/water.tres
+++ b/addons/qodot/game_definitions/worldspawn_layers/liquid/water.tres
@@ -1,15 +1,14 @@
-[gd_resource type="Resource" load_steps=3 format=2]
+[gd_resource type="Resource" script_class="QodotWorldspawnLayer" load_steps=3 format=3 uid="uid://d4hwu1l0dcldv"]
 
-[ext_resource path="res://addons/qodot/src/resources/worldspawn_layer.gd" type="Script" id=1]
-[ext_resource path="res://addons/qodot/game_definitions/worldspawn_layers/liquid/water.gd" type="Script" id=2]
-
+[ext_resource type="Script" path="res://addons/qodot/src/resources/worldspawn_layer.gd" id="1"]
+[ext_resource type="Script" path="res://addons/qodot/game_definitions/worldspawn_layers/liquid/water.gd" id="2"]
 
 [resource]
 resource_name = "Water Layer"
-script = ExtResource( 1 )
+script = ExtResource("1")
 name = "water"
 texture = "layers/water"
 node_class = "Area"
 build_visuals = true
 collision_shape_type = 1
-script_class = ExtResource( 2 )
+script_class = ExtResource("2")


### PR DESCRIPTION
Hi! I've gone through every resource and manually saved them again using Godot version 4.0.3, so the resource definition gets updated to the format used nowadays.

In my tests, this doesn't fully fix the `build_def_text` error that sometimes happen, but I think is needed nonetheless.