### PR TITLE
Properly dispose of FileAccess objects

### DIFF
--- a/addons/qodot/src/core/MapParser.cs
+++ b/addons/qodot/src/core/MapParser.cs
@@ -56,7 +56,7 @@ namespace Qodot
 
 			scope = ParseScope.FILE;
 
-			FileAccess file = FileAccess.Open(filename, FileAccess.ModeFlags.Read);
+			using FileAccess file = FileAccess.Open(filename, FileAccess.ModeFlags.Read);
 			if (file == null)
 			{
 				GD.PrintErr("Error: Failed to open map file (" + filename + ")");

--- a/addons/qodot/src/import_plugins/QuakeWadImportPlugin.cs
+++ b/addons/qodot/src/import_plugins/QuakeWadImportPlugin.cs
@@ -121,7 +121,7 @@ public partial class QuakeWadImportPlugin : EditorImportPlugin
 
 		string savePathStr = savePath + "." + _GetSaveExtension();
 
-		var file = FileAccess.Open(sourceFile, FileAccess.ModeFlags.Read);
+		using var file = FileAccess.Open(sourceFile, FileAccess.ModeFlags.Read);
 		if (file == null)
 		{
 			Error err = FileAccess.GetOpenError();


### PR DESCRIPTION
Quick fix to avoid keeping the files locked after Qodot finishes processing them.
This fixes Trenchboom being unable to save the map file after a Full Build in Godot