### PR TITLE
add target and targetname to some classes

### DIFF
--- a/addons/qodot/game_definitions/fgd/solid_classes/button_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/button_solid_class.tres
@@ -25,7 +25,8 @@ class_properties = {
 "release_delay": 0.0,
 "release_signal_delay": 0.0,
 "speed": 8.0,
-"trigger_signal_delay": 0.0
+"trigger_signal_delay": 0.0,
+"target": ""
 }
 class_property_descriptions = {}
 meta_properties = {}

--- a/addons/qodot/game_definitions/fgd/solid_classes/mover_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/mover_solid_class.tres
@@ -22,7 +22,8 @@ class_properties = {
 "rotation": Vector3(0, 0, 0),
 "scale": Vector3(1, 1, 1),
 "speed": 1.0,
-"translation": Vector3(0, 0, 0)
+"translation": Vector3(0, 0, 0),
+"targetname": ""
 }
 class_property_descriptions = {}
 meta_properties = {}

--- a/addons/qodot/game_definitions/fgd/solid_classes/trigger_solid_class.tres
+++ b/addons/qodot/game_definitions/fgd/solid_classes/trigger_solid_class.tres
@@ -18,7 +18,9 @@ classname = "trigger"
 description = "Trigger Volume"
 qodot_internal = false
 base_classes = Array[Resource]([])
-class_properties = {}
+class_properties = {
+"target": ""
+}
 class_property_descriptions = {}
 meta_properties = {}
 node_options = "----------------------------------------------------------------"


### PR DESCRIPTION
I've added target to triggers and buttons so if someone decides to use them, they don't have to add it in themselves.
I've done this in my personal project, and found it quite convenient, so others will probably also find it convenient :D

Same reasoning with adding targetname to movers.


P.S: this is my first pull request, please be gentle if I did something wrong <3 