### PR TITLE
Add _get_priority() to quake_palette_import_plugin.gd

### DIFF
--- a/addons/qodot/src/import_plugins/quake_palette_import_plugin.gd
+++ b/addons/qodot/src/import_plugins/quake_palette_import_plugin.gd
@@ -24,6 +24,9 @@ func _get_import_options(path, preset):
 
 func _get_preset_count() -> int:
 	return 0
+
+func _get_priority():
+	return 1.0
 	
 func _get_import_order():
 	return 0


### PR DESCRIPTION
In certain circumstances Godot will get upset about the absence of the _get_priority() method in an EditorImportPlugin and cause issues with importing custom file types.

For some reason in Qodot, this could cause all custom file types to fail (map, lmp, wad) and spam error messages. Adding the missing _get_priority() has cleared these errors up and allowed all file types to import properly again.