### PR TITLE
Add support for Choices Default Value

### DIFF
--- a/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_class.gd
+++ b/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_class.gd
@@ -84,7 +84,17 @@ func build_def_text() -> String:
 
 		var prop_val = null
 		var prop_type := ""
-		var prop_description: String = class_property_descriptions[prop] if prop in class_property_descriptions else ""
+		var prop_description: String
+		if prop in class_property_descriptions:
+			# Optional default value for Choices can be set up as [String, int]
+			if value is Dictionary and class_property_descriptions[prop] is Array:
+				var prop_arr: Array = class_property_descriptions[prop]
+				if prop_arr.size() > 1 and prop_arr[1] is int:
+					prop_description = "\"" + prop_arr[0] + "\" : " + str(prop_arr[1])
+			else:
+				prop_description = "\"" + class_property_descriptions[prop] + "\""
+		else:
+			prop_description = ""
 
 		if value is int:
 			prop_type = "integer"
@@ -135,9 +145,8 @@ func build_def_text() -> String:
 			res += ")"
 
 			if not value is Array:
-				res += " : \""
+				res += " : "
 				res += prop_description
-				res += "\" "
 
 			if value is Dictionary or value is Array:
 				res += " = "


### PR DESCRIPTION
Choices properties can have an optional default value passed in an FGD. Qodot was unable to do this before.

Proposed change has the optional default value defined in the Class Property Descriptions. To define it, use an Array with the format [String, int].

Falls back to normal behavior if the description is not for a Choices property or the description is not an Array.