### PR TITLE
Fixed broken Flags and Choices default properties

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -1092,7 +1092,25 @@ func apply_properties() -> void:
 				# Assign properties not defined with defaults from the entity definition
 				for property in entity_definitions[classname].class_properties:
 					if not property in properties:
-						properties[property] = entity_definition.class_properties[property]
+						var prop_default = entity_definition.class_properties[property]
+						# Flags
+						if prop_default is Array:
+							var prop_flags_sum := 0
+							for prop_flag in prop_default:
+								if prop_flag is Array and prop_flag.size() == 3:
+									if prop_flag[2] and prop_flag[1] is int:
+										prop_flags_sum += prop_flag[1]
+							properties[property] = prop_flags_sum
+						# Choices
+						elif prop_default is Dictionary:
+							var prop_desc = entity_definition.class_property_descriptions[property]
+							if prop_desc is Array and prop_desc.size() > 1 and prop_desc[1] is int:
+								properties[property] = prop_desc[1]
+							else:
+								properties[property] = 0
+						# Everything else
+						else:
+							properties[property] = prop_default
 						
 		if 'properties' in entity_node:
 			entity_node.properties = properties


### PR DESCRIPTION
When building a map, if an entity is missing key value pairs due to not being filled out in Trenchbroom (grayed out key values) then Qodot will attempt to fill the missing properties with their defaults.

Flags and Choices are set up using Arrays and Dictionaries. If the value is found, they correctly apply integers to the property. If the value isn't found, they become the Arrays and Dictionaries defined in the FGD Class resource.

With the fix, Flags will now sum up properly to the default Flag settings, and Choices will automatically be set to the correct choice if the optional default is provided.