### PR TITLE
Use editor setting for trenchbroom game folder

### DIFF
--- a/addons/qodot/src/qodot_plugin.gd
+++ b/addons/qodot/src/qodot_plugin.gd
@@ -10,6 +10,8 @@ var qodot_map_control: Control = null
 var qodot_map_progress_bar: Control = null
 var edited_object_ref: WeakRef = weakref(null)
 
+static var editor_settings: EditorSettings
+
 func _get_plugin_name() -> String:
 	return "Qodot"
 
@@ -29,6 +31,9 @@ func _make_visible(visible: bool) -> void:
 func _enter_tree() -> void:
 	# Project settings
 	setup_project_settings()
+	
+	# Editor settings
+	setup_editor_settings()
 
 	var csharp_support := QodotUtil.has_csharp_support()
 	if not csharp_support:
@@ -81,6 +86,18 @@ func _exit_tree() -> void:
 		remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_BOTTOM, qodot_map_progress_bar)
 		qodot_map_progress_bar.queue_free()
 		qodot_map_progress_bar = null
+
+func setup_editor_settings() -> void:
+	editor_settings = get_editor_interface().get_editor_settings()
+	if !editor_settings.has_setting('qodot/trenchbroom/game_config_path'):
+		editor_settings.set_setting('qodot/trenchbroom/game_config_path', '')
+	
+	var pinfo = {
+		'name': 'qodot/trenchbroom/game_config_path',
+		'type': TYPE_STRING,
+		'hint': PROPERTY_HINT_GLOBAL_DIR,
+	}
+	editor_settings.add_property_info(pinfo)
 
 ## Add Qodot-specific settings to Godot's Project Settings
 func setup_project_settings() -> void:

--- a/addons/qodot/src/resources/game-definitions/trenchbroom_game_config.gd
+++ b/addons/qodot/src/resources/game-definitions/trenchbroom_game_config.gd
@@ -172,7 +172,12 @@ func parse_flags(flags: Array) -> String:
 
 ## Exports or updates a folder in the /games directory, with an icon, .cfg, and all accompanying FGDs.
 func do_export_file():
-	if trenchbroom_games_folder.is_empty():
+	# Try the folder from settings first
+	var folder = QodotPlugin.editor_settings.get_setting("qodot/trenchbroom/game_config_path")
+	if !folder || folder.is_empty():
+		# Try the folder on the resource
+		folder = trenchbroom_games_folder
+	if folder.is_empty():
 		print("Skipping export: No TrenchBroom games folder")
 		return
 	# Create config folder name by combining games folder with the game name as a directory


### PR DESCRIPTION
Moving the trenchbroom game folder into an editor setting means it doesn't get committed to source control when working on a project with someone else. Can be unique for each development environment.

This will fallback to using the trenchbroom folder on the resource if the editor setting isn't set, which should make it a non-breaking change.