### PR TITLE
Fix Concave, Skip and Clip Collision Build Bugs

### DIFF
--- a/addons/qodot/src/core/GeoGenerator.cs
+++ b/addons/qodot/src/core/GeoGenerator.cs
@@ -167,16 +167,16 @@ namespace Qodot
 					}
 
 					if (vertexCount > 0)
-						{
-							brush.center /= (float)vertexCount;
-//							entity.center += brush.center;
-						}
+					{
+						brush.center /= (float)vertexCount;
+					}
+					entity.center += brush.center;
 				}
 
 				if (brushSpan.Length > 0)
-					{
-						entity.center /= (float)brushSpan.Length;
-					}
+				{
+					entity.center /= (float)brushSpan.Length;
+				}
 			}
 		}
 

--- a/addons/qodot/src/core/SurfaceGatherer.cs
+++ b/addons/qodot/src/core/SurfaceGatherer.cs
@@ -34,6 +34,7 @@ namespace Qodot
 			if (splitType == SurfaceSplitType.NONE)
 			{
 				surfIdx = AddSurface();
+				index_offset = outSurfaces[surfIdx].vertices.Count;
 			}
 
 			Span<Entity> entitySpan = mapData.GetEntitiesSpan();

--- a/addons/qodot/src/core/SurfaceGatherer.cs
+++ b/addons/qodot/src/core/SurfaceGatherer.cs
@@ -56,6 +56,7 @@ namespace Qodot
 				Span<BrushGeometry> brushGeoSpan = mapData.GetBrushGeoSpan(e);
 				for (int b = 0; b < brushGeoSpan.Length; b++)
 				{
+					if (FilterBrush(e, b)) continue;
 
 					if (splitType == SurfaceSplitType.BRUSH)
 					{
@@ -73,13 +74,14 @@ namespace Qodot
 						Span<FaceVertex> vertexSpan = CollectionsMarshal.AsSpan(faceGeo.vertices);
 						for (int v = 0; v < vertexSpan.Length; v++)
 						{
+							FaceVertex vertex = vertexSpan[v];
+							
 							if (entitySpan[e].spawnType == EntitySpawnType.ENTITY ||
 								entitySpan[e].spawnType == EntitySpawnType.GROUP)
 							{
-								vertexSpan[v].vertex -= entitySpan[e].center;
+								vertex.vertex -= entitySpan[e].center;
 							}
-							if(FilterBrush(e, b)) continue;
-							outSurfaces[surfIdx].vertices.Add(vertexSpan[v]);
+							outSurfaces[surfIdx].vertices.Add(vertex);
 						}
 						
 						for (int i = 0; i < (faceGeo.vertices.Count - 2) * 3; i++)

--- a/addons/qodot/src/core/SurfaceGatherer.cs
+++ b/addons/qodot/src/core/SurfaceGatherer.cs
@@ -31,7 +31,10 @@ namespace Qodot
 
 			int surfIdx = -1;
 
-			if (splitType == SurfaceSplitType.NONE) AddSurface();
+			if (splitType == SurfaceSplitType.NONE)
+			{
+				surfIdx = AddSurface();
+			}
 
 			Span<Entity> entitySpan = mapData.GetEntitiesSpan();
 			for (int e = 0; e < entitySpan.Length; e++)

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -764,7 +764,7 @@ func build_entity_collision_shapes() -> void:
 				var vertices := surface_verts[Mesh.ARRAY_VERTEX] as PackedVector3Array
 				var indices := surface_verts[Mesh.ARRAY_INDEX] as PackedInt32Array
 				for vert_idx in indices:
-					entity_verts.append(vertices[vert_idx] + entity_position)
+					entity_verts.append(vertices[vert_idx])
 			else:
 				var shape_points = PackedVector3Array()
 				for vertex in surface_verts[Mesh.ARRAY_VERTEX]:

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -768,7 +768,6 @@ func build_entity_collision_shapes() -> void:
 			else:
 				var shape_points = PackedVector3Array()
 				for vertex in surface_verts[Mesh.ARRAY_VERTEX]:
-					vertex += entity_position
 					if not vertex in shape_points:
 						shape_points.append(vertex)
 				


### PR DESCRIPTION
Most of Qodot's MapData is passed by Span, a data type that references another existing value. Modifying the Span value will modify the original value as well.

Qodot generates Mesh and Collision Shape data running 2 passes of SurfaceGatherer.Run() on each Entity. During each Run(), SurfaceGatherer loops through each Brush and Face of an SolidEntity, checking if the current Brush or Face it's on should be skipped. It then loops through each Vertex of the current Face. If the current SolidEntity is an Entity or Group type, it subtracts the center position from the current Vertex. Then finally it adds the Vertex to the Surface Output.

The problem is that it loops through the Vertices as a Span type, which is passed by reference. Therefore, every time the Entity's Center position is subtracted from the Vertex, it modifies the original value. For Skip textures, it only ends subtracting from this value once because they are filtered out during the Mesh Generation Run. Meanwhile, all other texture types are subtracted twice, causing the sets of vertices to be offset.

The fix is to copy the Span's current FaceVertex (vertexSpan[v]) to a new local FaceVertex struct, then modify the copied value and insert that into the Output array, leaving the original MapData intact.

With this change, there is no longer a need to add the entity.center to the vertex position in qodot_map.gd's build_entity_collision_shapes() function, nor is there any need to comment out GeoGenerator's entity.center += brush.center line.

FilterBrush is also moved back to the start of the Brush loop as in the original Qodot for 3.5. This seems to solve the crashes related to Clip texture filtering.

Tested both on the default qodot.fgd with worldspawn and on a custom FGD with special SolidEntity classes.