### PR TITLE
Added support for Node2D and Control derived entities

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -485,7 +485,6 @@ func build_entity_nodes() -> Array:
 		else:
 			if entity_idx != 0 and "position" in node:
 				if node.position is Vector3:
-					print(entity_dict['center'])
 					node.position = entity_dict['center'] / inverse_scale_factor
 		
 		entity_nodes.append(node)

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -478,10 +478,15 @@ func build_entity_nodes() -> Array:
 			var origin_comps = properties['origin'].split(' ')
 			var origin_vec = Vector3(origin_comps[1].to_float(), origin_comps[2].to_float(), origin_comps[0].to_float())
 			if "position" in node:
-				node.position = origin_vec / inverse_scale_factor
+				if node.position is Vector3:
+					node.position = origin_vec / inverse_scale_factor
+				elif node.position is Vector2:
+					node.position = Vector2(origin_vec.z, -origin_vec.y)
 		else:
 			if entity_idx != 0 and "position" in node:
-				node.position = entity_dict['center'] / inverse_scale_factor
+				if node.position is Vector3:
+					print(entity_dict['center'])
+					node.position = entity_dict['center'] / inverse_scale_factor
 		
 		entity_nodes.append(node)
 		


### PR DESCRIPTION
I'm an idiot and accidentally deleted the original pull request for this.

I realized if you somehow decided to set up a Node2D or Control as an entity you'd end up with an error trying to apply a Vector3 value to a Vector2 property. Instead of blocking this possibility, I added a check to allow for Vector2 compatibility.

In Trenchbroom you position the 2D entity from the top down view. When built in Godot, the entity will be positioned according to the X and -Y origin values, eg: Vector3(64, -64, -1268) becomes Vector2(64, 64).

This will allow mappers to add things like per map UI elements or screen effects without needing to anchor them to a Node3D.