### PR TITLE
Fix float parsing for comma decimal locales

### DIFF
--- a/addons/qodot/src/core/MapParser.cs
+++ b/addons/qodot/src/core/MapParser.cs
@@ -263,13 +263,13 @@ namespace Qodot
 					else
 					{
 						valveUVs = false;
-						currentFace.uvStandard.X = token.ToFloat();
+						currentFace.uvStandard.X = (float)Convert.ToDouble(token, System.Globalization.CultureInfo.InvariantCulture.NumberFormat);
 						scope = ParseScope.V;
 					}
 
 					break;
 				case ParseScope.V:
-					currentFace.uvStandard.Y = token.ToFloat();
+					currentFace.uvStandard.Y = (float)Convert.ToDouble(token, System.Globalization.CultureInfo.InvariantCulture.NumberFormat);
 					scope = ParseScope.ROT;
 					break;
 				case ParseScope.VALVE_U:


### PR DESCRIPTION
Some people in locales that use a comma as a decimal point are having parsing errors, see https://github.com/QodotPlugin/Qodot/issues/57

The rest of the file uses ToDouble with invariant culture which would not have this issue, so I updated these two lines to do the same.