### PR TITLE
Proposal: Skip and Clip Collision Generation Behavior Change

### DIFF
--- a/addons/qodot/src/core/Qodot.cs
+++ b/addons/qodot/src/core/Qodot.cs
@@ -161,24 +161,24 @@ namespace Qodot
 			return entDicts;
 		}
 
-		public void GatherTextureSurfaces(string texName, string brushFilterTex, string faceFilterTex)
+		public void GatherTextureSurfaces(string texName, string clipFilterTex, string skipFilterTex)
 		{
-			GatherTextureSurfacesInternal(texName, brushFilterTex, faceFilterTex, true);
+			GatherTextureSurfacesInternal(texName, clipFilterTex, skipFilterTex, true);
 		}
 
-		public void GatherWorldspawnLayerSurfaces(string texName, string brushFilterTex, string faceFilterTex)
+		public void GatherWorldspawnLayerSurfaces(string texName, string clipFilterTex, string skipFilterTex)
 		{
-			GatherTextureSurfacesInternal(texName, brushFilterTex, faceFilterTex, false);
+			GatherTextureSurfacesInternal(texName, clipFilterTex, skipFilterTex, false);
 		}
 
-		private void GatherTextureSurfacesInternal(string texName, string brushFilterTex, string faceFilterTex,
+		private void GatherTextureSurfacesInternal(string texName, string clipFilterTex, string skipFilterTex,
 			bool filterLayers)
 		{
 			surfaceGatherer.ResetParams();
 			surfaceGatherer.splitType = SurfaceSplitType.ENTITY;
 			surfaceGatherer.SetTextureFilter(texName);
-			surfaceGatherer.SetBrushFilterTexture(brushFilterTex);
-			surfaceGatherer.SetFaceFilterTexture(faceFilterTex);
+			surfaceGatherer.SetclipFilterTexture(clipFilterTex);
+			surfaceGatherer.SetskipFilterTexture(skipFilterTex);
 			surfaceGatherer.filterWorldspawnLayers = filterLayers;
 			
 			surfaceGatherer.Run();
@@ -189,9 +189,9 @@ namespace Qodot
 			GatherConvexCollisionSurfaces(entityIdx, true);
 		}
 		
-		public void GatherEntityConcaveCollisionSurfaces(int entityIdx, string faceFilterTex)
+		public void GatherEntityConcaveCollisionSurfaces(int entityIdx, string skipFilterTex)
 		{
-			GatherConcaveCollisionSurfaces(entityIdx, faceFilterTex, true);
+			GatherConcaveCollisionSurfaces(entityIdx, skipFilterTex, true);
 		}
 
 		public void GatherWorldspawnLayerCollisionSurfaces(int entityIdx)
@@ -209,12 +209,12 @@ namespace Qodot
 			surfaceGatherer.Run();
 		}
 		
-		private void GatherConcaveCollisionSurfaces(int entityIdx, string faceFilterTex, bool filterLayers)
+		private void GatherConcaveCollisionSurfaces(int entityIdx, string skipFilterTex, bool filterLayers)
 		{
 			surfaceGatherer.ResetParams();
 			surfaceGatherer.splitType = SurfaceSplitType.NONE;
 			surfaceGatherer.entityFilterIdx = entityIdx;
-			surfaceGatherer.SetFaceFilterTexture(faceFilterTex);
+			surfaceGatherer.SetskipFilterTexture(skipFilterTex);
 			surfaceGatherer.filterWorldspawnLayers = filterLayers;
 			
 			surfaceGatherer.Run();

--- a/addons/qodot/src/core/Qodot.cs
+++ b/addons/qodot/src/core/Qodot.cs
@@ -189,9 +189,9 @@ namespace Qodot
 			GatherConvexCollisionSurfaces(entityIdx, true);
 		}
 		
-		public void GatherEntityConcaveCollisionSurfaces(int entityIdx)
+		public void GatherEntityConcaveCollisionSurfaces(int entityIdx, string faceFilterTex)
 		{
-			GatherConcaveCollisionSurfaces(entityIdx, true);
+			GatherConcaveCollisionSurfaces(entityIdx, faceFilterTex, true);
 		}
 
 		public void GatherWorldspawnLayerCollisionSurfaces(int entityIdx)
@@ -209,11 +209,12 @@ namespace Qodot
 			surfaceGatherer.Run();
 		}
 		
-		private void GatherConcaveCollisionSurfaces(int entityIdx, bool filterLayers)
+		private void GatherConcaveCollisionSurfaces(int entityIdx, string faceFilterTex, bool filterLayers)
 		{
 			surfaceGatherer.ResetParams();
 			surfaceGatherer.splitType = SurfaceSplitType.NONE;
 			surfaceGatherer.entityFilterIdx = entityIdx;
+			surfaceGatherer.SetFaceFilterTexture(faceFilterTex);
 			surfaceGatherer.filterWorldspawnLayers = filterLayers;
 			
 			surfaceGatherer.Run();

--- a/addons/qodot/src/core/SurfaceGatherer.cs
+++ b/addons/qodot/src/core/SurfaceGatherer.cs
@@ -154,6 +154,9 @@ namespace Qodot
 			Span<Face> faceSpan = mapData.GetFacesSpan(entityIdx, brushIdx);
 			Span<FaceGeometry> faceGeoSpan = mapData.GetFaceGeoSpan(entityIdx, brushIdx);
 			if (faceGeoSpan[faceIdx].vertices.Count < 3) return true;
+
+			// Omit faces textured with clip.
+			if (brushFilterTextureIdx != -1 && faceSpan[faceIdx].textureIdx == brushFilterTextureIdx) return true;
 			
 			// Omit faces textured with skip.
 			if (faceFilterTextureIdx != -1 && faceSpan[faceIdx].textureIdx == faceFilterTextureIdx) return true;

--- a/addons/qodot/src/core/SurfaceGatherer.cs
+++ b/addons/qodot/src/core/SurfaceGatherer.cs
@@ -14,8 +14,8 @@ namespace Qodot
 		public SurfaceSplitType splitType = SurfaceSplitType.NONE;
 		public int entityFilterIdx = -1;
 		public int textureFilterIdx = -1;
-		public int brushFilterTextureIdx;
-		public int faceFilterTextureIdx;
+		public int clipFilterTextureIdx;
+		public int skipFilterTextureIdx;
 		public bool filterWorldspawnLayers;
 		
 		public SurfaceGatherer(MapData mapData)
@@ -104,14 +104,14 @@ namespace Qodot
 			textureFilterIdx = mapData.FindTexture(textureName);
 		}
 
-		public void SetBrushFilterTexture(string textureName)
+		public void SetclipFilterTexture(string textureName)
 		{
-			brushFilterTextureIdx = mapData.FindTexture(textureName);
+			clipFilterTextureIdx = mapData.FindTexture(textureName);
 		}
 
-		public void SetFaceFilterTexture(string textureName)
+		public void SetskipFilterTexture(string textureName)
 		{
-			faceFilterTextureIdx = mapData.FindTexture(textureName);
+			skipFilterTextureIdx = mapData.FindTexture(textureName);
 		}
 
 		private bool FilterEntity(int entityIdx)
@@ -123,12 +123,12 @@ namespace Qodot
 		{
 			Span<Face> faceSpan = mapData.GetFacesSpan(entityIdx, brushIdx);
 
-			if (brushFilterTextureIdx != -1)
+			if (clipFilterTextureIdx != -1)
 			{
 				bool fullyTextured = true;
 				for (int f = 0; f < faceSpan.Length; f++)
 				{
-					if (faceSpan[f].textureIdx != brushFilterTextureIdx)
+					if (faceSpan[f].textureIdx != clipFilterTextureIdx)
 					{
 						fullyTextured = false;
 						break;
@@ -156,10 +156,10 @@ namespace Qodot
 			if (faceGeoSpan[faceIdx].vertices.Count < 3) return true;
 
 			// Omit faces textured with clip.
-			if (brushFilterTextureIdx != -1 && faceSpan[faceIdx].textureIdx == brushFilterTextureIdx) return true;
+			if (clipFilterTextureIdx != -1 && faceSpan[faceIdx].textureIdx == clipFilterTextureIdx) return true;
 			
 			// Omit faces textured with skip.
-			if (faceFilterTextureIdx != -1 && faceSpan[faceIdx].textureIdx == faceFilterTextureIdx) return true;
+			if (skipFilterTextureIdx != -1 && faceSpan[faceIdx].textureIdx == skipFilterTextureIdx) return true;
 			
 			// Omit filtered texture indices.
 			if (textureFilterIdx != -1 && faceSpan[faceIdx].textureIdx != textureFilterIdx) return true;
@@ -178,8 +178,8 @@ namespace Qodot
 			splitType = SurfaceSplitType.NONE;
 			entityFilterIdx = -1;
 			textureFilterIdx = -1;
-			brushFilterTextureIdx = -1;
-			faceFilterTextureIdx = -1;
+			clipFilterTextureIdx = -1;
+			skipFilterTextureIdx = -1;
 			filterWorldspawnLayers = true;
 		}
 	}

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -746,7 +746,7 @@ func build_entity_collision_shapes() -> void:
 			continue
 		
 		if concave:
-			qodot.GatherEntityConcaveCollisionSurfaces(entity_idx)
+			qodot.GatherEntityConcaveCollisionSurfaces(entity_idx, face_skip_texture)
 		else:
 			qodot.GatherEntityConvexCollisionSurfaces(entity_idx)
 		


### PR DESCRIPTION
Some time back @DeerTears and I talked about possibly changing how Qodot treats _Clip_ and _Skip_ textures, due to how redundant they were (actually, turns out _Skip_  was a lot more useful than _Clip_). [You can find that discussion here](https://github.com/QodotPlugin/Qodot/issues/72).

I decided to go ahead and implement my proposal in a personal project using Qodot, and I think it works quite well without breaking any Qodot projects. I hope it's not too presumptive of me to make a pull request for it already, but I feel this change would be extremely useful for map designers of all skill levels.

### Current Behavior
The current behavior works extremely similar to the way modern Quake 1 BSP compiling handles _Clip_ and _Skip_ texturing. In the original compilers back in 1996, if a brush was completely textured in the _Clip_ texture, the brush's faces would not be drawn while maintaining collision. If I recall correctly, _Skip_ came in later BSP compilers in order to cull individual faces. Once again, collision remained the same. This is effectively how Qodot has handled this since Godot 3.

However, the question arises: if _Skip_ can cull both an entire brush and individual brush faces from the generated mesh, then what's the point of _Clip_?

Additionally, when generating **concave** collision, it is often better to simplify the collision shape as much as possible. Currently the concave collision shape faces generated are the same as the convex shape faces, just with fewer nodes, leaving an inability to optimize concave collision in solid entities.

### Proposed Behavior Change
When constructing **concave** collision, _Clip_ textured brush faces should always be culled from the mesh but always generate collision while _Skip_ textured brush faces should always be culled from both mesh and collision generation. This would remove their near identical functionality and provide a valid reason to still use both. Convex brushes will not remove _Skip_ faces from collision generation, in order to prevent unpredictable behavior.

### Implementation
_Skip_ and _Clip_ are both checked in [SurfaceGatherer's FilterFace](https://github.com/QodotPlugin/Qodot/blob/main/addons/qodot/src/core/SurfaceGatherer.cs#L146) method during [Qodot's mesh generation](https://github.com/QodotPlugin/Qodot/blob/main/addons/qodot/src/core/Qodot.cs#L174). Then, during the [Qodot's concave collision generation](https://github.com/QodotPlugin/Qodot/blob/main/addons/qodot/src/core/Qodot.cs#L212) we filter out the _Skip_ face again, but not during convex collision generation. This allows skipping the _Skip_ face collision generation while maintaining the _Clip_ face collision. This also means we can avoid a post-build `create_trimesh_shape()` hack, only needing to go through the build process once as it currently works. It also takes advantage of the same face removal as the mesh generation does, which means it should build the collision you expect.

### Summary
**Current Behavior**
- _Clip_ removes faces only when the entire brush is textured with _Clip_
- _Skip_ removes each face textured with _Skip_ regardless of brush coverage
- Collision is maintained regardless of _Clip_ or _Skip_ texturing

**Proposed Behavior**
- Both _Clip_ and _Skip_ remove each face regardless of brush coverage
- Collision is maintained regardless of _Clip_ texturing
- Convex collision maintains collision regardless of _Skip_ texturing
- Concave collision removes collision faces if textured with _Skip_

### Example Project
[QodotSkipClipTest.zip](https://github.com/QodotPlugin/Qodot/files/12755034/QodotSkipClipTest.zip)

The example project uses the default example `qodot.fgd`, but with `wall_solid_class.tres` modified to generate concave collision instead of convex.

The example map shows off several `wall` solid entities that are completely textured with _Clip_ or _Skip_, partially textured with them, and even mixed together. The collision builds just as the proposed behavior describes.

![image](https://github.com/QodotPlugin/Qodot/assets/44485952/3516ccab-384a-4920-8b36-aa3d6b31a288)
![image](https://github.com/QodotPlugin/Qodot/assets/44485952/d0d1da5b-81a8-47eb-99f8-cea34d124f93)

Hope this proposal gets approved! I think it'd be extremely helpful for a lot of devs to have that much more control over culling and collision.