### PR TITLE
Fix TrenchBroomTag Default Attributes

### DIFF
--- a/addons/qodot/src/resources/game-definitions/trenchbroom/trenchbroom_tag.gd
+++ b/addons/qodot/src/resources/game-definitions/trenchbroom/trenchbroom_tag.gd
@@ -18,7 +18,7 @@ enum TagMatchType {
 
 ## The attributes applied to matching faces or brushes. Only "_transparent" is
 ## supported in Trenchbroom, which makes matching faces or brushes transparent.
-@export var tag_attributes : Array[String] = ["_transparent"]
+@export var tag_attributes : Array[String] = ["transparent"]
 
 ## Detemines how the tag is matched. See [constant TagMatchType].
 @export var tag_match_type: TagMatchType


### PR DESCRIPTION
The default value in tag attributes is `_transparent`, but this is not a valid attribute in TrenchBroom. This causes TrenchBroom to crash on startup.

Fixed by replacing the default entry with the valid `transparent` tag attribute.