### PR TITLE
Fix: Prevent Solid Entity Classes Having Size or Model Meta Properties

### DIFF
--- a/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_class.gd
+++ b/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_class.gd
@@ -47,6 +47,10 @@ func build_def_text() -> String:
 		meta_props['base'] = base_str
 
 	for prop in meta_props:
+		if self is QodotFGDSolidClass:
+			if prop == "size" or prop == "model":
+				continue
+		
 		var value = meta_props[prop]
 		res += " " + prop + "("
 


### PR DESCRIPTION
If a brush entity has a `size` meta property it will throw an error on FGD load.

> Reloading entity definitions
> Solid entity definition must not have a size (line 21, column 13)
> Loaded entity definition file QodotTutorial.fgd

The FGD will still load and you can still map, but an error's an error.

This fix adds a check to see if the resource is a Solid Class and if the current meta property is an invalid type for brush entities. If it is, it moves on to the next meta property.