### PR TITLE
Add: SolidClass Collision Control

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -654,6 +654,11 @@ func build_entity_collision_shape_nodes() -> Array:
 					if entity_definition.spawn_type == QodotFGDSolidClass.SpawnType.MERGE_WORLDSPAWN:
 						# TODO: Find the worldspawn object instead of assuming index 0
 						node = entity_nodes[0] as Node
+
+					if node and node is CollisionObject3D:
+						(node as CollisionObject3D).collision_layer = entity_definition.collision_layer
+						(node as CollisionObject3D).collision_mask = entity_definition.collision_mask
+						(node as CollisionObject3D).collision_priority = entity_definition.collision_priority
 		
 		# don't create collision shapes that wont be attached to a CollisionObject3D as they are a waste
 		if not node or (not node is CollisionObject3D):
@@ -731,7 +736,8 @@ func build_entity_collision_shapes() -> void:
 		if entity_collision_shape == null:
 			continue
 		
-		var concave = false
+		var concave: bool = false
+		var shape_margin: float = 0.04
 		
 		if 'classname' in properties:
 			var classname = properties['classname']
@@ -745,6 +751,7 @@ func build_entity_collision_shapes() -> void:
 							concave = false
 						QodotFGDSolidClass.CollisionShapeType.CONCAVE:
 							concave = true
+					shape_margin = entity_definition.collision_shape_margin
 		
 		if entity_collision_shapes[entity_idx] == null:
 			continue
@@ -777,6 +784,7 @@ func build_entity_collision_shapes() -> void:
 				
 				var shape = ConvexPolygonShape3D.new()
 				shape.set_points(shape_points)
+				shape.margin = shape_margin
 				
 				var collision_shape = entity_collision_shape[surface_idx]
 				collision_shape.set_shape(shape)
@@ -787,6 +795,7 @@ func build_entity_collision_shapes() -> void:
 			
 			var shape = ConcavePolygonShape3D.new()
 			shape.set_faces(entity_verts)
+			shape.margin = shape_margin
 			
 			var collision_shape = entity_collision_shapes[entity_idx][0]
 			collision_shape.set_shape(shape)

--- a/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
+++ b/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
@@ -26,6 +26,14 @@ enum CollisionShapeType {
 @export_group("Collision Build")
 ## Controls how collisions are built for this SolidClass
 @export var collision_shape_type: CollisionShapeType = CollisionShapeType.CONVEX
+## The physics layers this SolidClass is in.
+@export_flags_3d_physics var collision_layer: int = 1
+## The physics layers this SolidClass scans.
+@export_flags_3d_physics var collision_mask: int = 1
+## The priority used to solve colliding when occurring penetration. The higher the priority is, the lower the penetration into the SolidClass will be. This can for example be used to prevent the player from breaking through the boundaries of a level.
+@export var collision_priority: float = 1.0
+## The collision margin for the SolidClass' collision shapes. Not used in Godot Physics. See Shape3D docs for details.
+@export var collision_shape_margin: float = 0.04
 
 @export_group("Scripting")
 ## The script file to associate with this SolidClass


### PR DESCRIPTION
It was discussed on the Qodot Discord to add options to control the collision layers and masks from the SolidClass resource. This includes the worldspawn entity, the default of which is just another SolidClass entity that map files set an origin of `0 0 0` to.

Additionally this PR also adds priority and shape margin options, for added flexibility. Shape margins aren't used in Godot Physics, but may be used in other physics implementations, so I thought this would be especially useful. See the CollisionObject3D and Shape3D docs for more details on priority and margin.

These changes do not break existing Qodot projects. The defaults used in the SolidClass entity are the same as those used by Godot.