### PR TITLE
Add: SolidClass Visual Control

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -917,6 +917,7 @@ func build_entity_mesh_instances() -> Dictionary:
 	var entity_mesh_instances := {}
 	for entity_idx in entity_mesh_dict:
 		var use_in_baked_light = false
+		var shadow_casting_setting := GeometryInstance3D.SHADOW_CASTING_SETTING_DOUBLE_SIDED
 		
 		var entity_dict := entity_dicts[entity_idx] as Dictionary
 		var properties = entity_dict['properties']
@@ -929,6 +930,7 @@ func build_entity_mesh_instances() -> Dictionary:
 				elif '_shadow' in properties:
 					if properties['_shadow'] == "1":
 						use_in_baked_light = true
+				shadow_casting_setting = entity_definition.shadow_casting_setting
 		
 		var mesh := entity_mesh_dict[entity_idx] as Mesh
 		
@@ -938,6 +940,7 @@ func build_entity_mesh_instances() -> Dictionary:
 		var mesh_instance := MeshInstance3D.new()
 		mesh_instance.name = 'entity_%s_mesh_instance' % entity_idx
 		mesh_instance.gi_mode = MeshInstance3D.GI_MODE_STATIC if use_in_baked_light else GeometryInstance3D.GI_MODE_DYNAMIC
+		mesh_instance.cast_shadow = shadow_casting_setting
 		
 		queue_add_child(entity_nodes[entity_idx], mesh_instance)
 		

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -927,6 +927,7 @@ func build_entity_mesh_instances() -> Dictionary:
 	for entity_idx in entity_mesh_dict:
 		var use_in_baked_light = false
 		var shadow_casting_setting := GeometryInstance3D.SHADOW_CASTING_SETTING_DOUBLE_SIDED
+		var render_layers: int = 1
 		
 		var entity_dict := entity_dicts[entity_idx] as Dictionary
 		var properties = entity_dict['properties']
@@ -940,6 +941,7 @@ func build_entity_mesh_instances() -> Dictionary:
 					if properties['_shadow'] == "1":
 						use_in_baked_light = true
 				shadow_casting_setting = entity_definition.shadow_casting_setting
+				render_layers = entity_definition.render_layers
 		
 		var mesh := entity_mesh_dict[entity_idx] as Mesh
 		
@@ -950,6 +952,7 @@ func build_entity_mesh_instances() -> Dictionary:
 		mesh_instance.name = 'entity_%s_mesh_instance' % entity_idx
 		mesh_instance.gi_mode = MeshInstance3D.GI_MODE_STATIC if use_in_baked_light else GeometryInstance3D.GI_MODE_DYNAMIC
 		mesh_instance.cast_shadow = shadow_casting_setting
+		mesh_instance.layers = render_layers
 		
 		queue_add_child(entity_nodes[entity_idx], mesh_instance)
 		

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -924,7 +924,7 @@ func build_entity_mesh_instances() -> Dictionary:
 		if classname in entity_definitions:
 			var entity_definition = entity_definitions[classname] as QodotFGDSolidClass
 			if entity_definition:
-				if entity_definition.spawn_type == QodotFGDSolidClass.SpawnType.WORLDSPAWN or entity_definition.spawn_type == QodotFGDSolidClass.SpawnType.GROUP:
+				if entity_definition.use_in_baked_light:
 					use_in_baked_light = true
 				elif '_shadow' in properties:
 					if properties['_shadow'] == "1":

--- a/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
+++ b/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
@@ -25,7 +25,7 @@ enum CollisionShapeType {
 ## Automatically unwrap the UV2 for lightmapping on build
 @export var use_in_baked_light := true
 ## Shadow casting setting allows for further lightmapping customization
-@export var shadow_casting_setting := GeometryInstance3D.SHADOW_CASTING_SETTING_DOUBLE_SIDED
+@export var shadow_casting_setting := GeometryInstance3D.SHADOW_CASTING_SETTING_ON
 
 @export_group("Collision Build")
 ## Controls how collisions are built for this SolidClass

--- a/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
+++ b/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
@@ -23,7 +23,7 @@ enum CollisionShapeType {
 ## Controls whether a visual mesh is built for this SolidClass
 @export var build_visuals := true
 ## Automatically unwrap the UV2 for lightmapping on build
-@export var unwrap_uv2 := true
+@export var use_in_baked_light := true
 
 @export_group("Collision Build")
 ## Controls how collisions are built for this SolidClass

--- a/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
+++ b/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
@@ -22,6 +22,8 @@ enum CollisionShapeType {
 @export_group("Visual Build")
 ## Controls whether a visual mesh is built for this SolidClass
 @export var build_visuals := true
+## Automatically unwrap the UV2 for lightmapping on build
+@export var unwrap_uv2 := true
 
 @export_group("Collision Build")
 ## Controls how collisions are built for this SolidClass

--- a/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
+++ b/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
@@ -26,6 +26,8 @@ enum CollisionShapeType {
 @export var use_in_baked_light := true
 ## Shadow casting setting allows for further lightmapping customization
 @export var shadow_casting_setting := GeometryInstance3D.SHADOW_CASTING_SETTING_ON
+## This entity will only be visible for Camera3Ds whose cull mask includes any of the render layers this VisualInstance3D is set to
+@export_flags_3d_render var render_layers: int = 1
 
 @export_group("Collision Build")
 ## Controls how collisions are built for this SolidClass

--- a/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
+++ b/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_solid_class.gd
@@ -24,6 +24,8 @@ enum CollisionShapeType {
 @export var build_visuals := true
 ## Automatically unwrap the UV2 for lightmapping on build
 @export var use_in_baked_light := true
+## Shadow casting setting allows for further lightmapping customization
+@export var shadow_casting_setting := GeometryInstance3D.SHADOW_CASTING_SETTING_DOUBLE_SIDED
 
 @export_group("Collision Build")
 ## Controls how collisions are built for this SolidClass


### PR DESCRIPTION
The Lightmap Enabling and UV2 Unwrapping in Qodot was either automatic for Worldspawn and Group SpawnTypes, or required an undocumented key value `_shadow` set to `1`. This seemed counter to both Qodot's core design pillar of non-assumptiveness and towards ease of use for commonly used major features of Godot.

I changed the behavior so that `SolidClass.SpawnType` is no longer taken into consideration, allowing all SpawnTypes to have their UV2s unwrapped by QodotMap's big shiny UV2 button. Instead, QodotMap now checks for a `use_in_baked_light` boolean set per SolidClass (this defaults to `true`). Setting this to `false` will exclude the SolidClass from lightmap baking, unless overridden in the entity's Script Class.

I also added a `shadow_casting_setting` variable to SolidClass, allowing you to decide what type of casting this entity will perform. This defaults to `On` though for backface culled world geometry it's recommended to set it to `Double-Sided`. This allows further control over default lighting settings for Qodot generated meshes.

Finally I added a `render_layers` variable. This will allow users to specify which cameras the mesh instance will be visible to.

All of these features feel important to add to the SolidClass entity due to them being tied to mesh generation in ways that other features were. It also feels more in line with making Qodot more flexible for users and reducing blackboxing.

None of these new features should be introducing any breaking changes.