### PR TITLE
Bug Fix: Invalid Vector Handling

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -480,7 +480,7 @@ func build_entity_nodes() -> Array:
 			if origin_comps.size() > 2:
 				origin_vec = Vector3(origin_comps[1], origin_comps[2], origin_comps[0])
 			else:
-				push_error("Invalid vector format for \'origin\' in " + node.name + ": " + prop_string)
+				push_error("Invalid vector format for \'origin\' in " + node.name)
 			if "position" in node:
 				if node.position is Vector3:
 					node.position = origin_vec / inverse_scale_factor

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -477,7 +477,7 @@ func build_entity_nodes() -> Array:
 		if 'origin' in properties:
 			var origin_vec = Vector3.ZERO
 			var origin_comps = properties['origin'].split_floats(' ')
-			if origin_comps.size() == 3:
+			if origin_comps.size() > 2:
 				origin_vec = Vector3(origin_comps[1], origin_comps[2], origin_comps[0])
 			else:
 				push_error("Invalid vector format for \'origin\' in " + node.name + ": " + prop_string)
@@ -1091,7 +1091,7 @@ func apply_properties() -> void:
 							properties[property] = prop_string.to_float()
 						elif prop_default is Vector3:
 							var prop_comps = prop_string.split_floats(" ")
-							if prop_comps.size() == 3:
+							if prop_comps.size() > 2:
 								properties[property] = Vector3(prop_comps[0], prop_comps[1], prop_comps[2])
 							else:
 								push_error("Invalid vector format for \'" + property + "\' in entity \'" + classname + "\': " + prop_string)
@@ -1099,7 +1099,7 @@ func apply_properties() -> void:
 						elif prop_default is Color:
 							var prop_color = prop_default
 							var prop_comps = prop_string.split(" ")
-							if prop_comps.size() == 3:
+							if prop_comps.size() > 2:
 								if "." in prop_comps[0] or "." in prop_comps[1] or "." in prop_comps[2]:
 									prop_color.r = prop_comps[0].to_float()
 									prop_color.g = prop_comps[1].to_float()
@@ -1125,7 +1125,7 @@ func apply_properties() -> void:
 						if prop_default is Array:
 							var prop_flags_sum := 0
 							for prop_flag in prop_default:
-								if prop_flag is Array and prop_flag.size() == 3:
+								if prop_flag is Array and prop_flag.size() > 2:
 									if prop_flag[2] and prop_flag[1] is int:
 										prop_flags_sum += prop_flag[1]
 							properties[property] = prop_flags_sum

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -475,8 +475,12 @@ func build_entity_nodes() -> Array:
 		node.name = node_name
 		
 		if 'origin' in properties:
-			var origin_comps = properties['origin'].split(' ')
-			var origin_vec = Vector3(origin_comps[1].to_float(), origin_comps[2].to_float(), origin_comps[0].to_float())
+			var origin_vec = Vector3.ZERO
+			var origin_comps = properties['origin'].split_floats(' ')
+			if origin_comps.size() == 3:
+				origin_vec = Vector3(origin_comps[1], origin_comps[2], origin_comps[0])
+			else:
+				push_error("Invalid vector format for \'origin\' in " + node.name + ": " + prop_string)
 			if "position" in node:
 				if node.position is Vector3:
 					node.position = origin_vec / inverse_scale_factor
@@ -1086,20 +1090,26 @@ func apply_properties() -> void:
 						elif prop_default is float:
 							properties[property] = prop_string.to_float()
 						elif prop_default is Vector3:
-							var prop_comps = prop_string.split(" ")
-							properties[property] = Vector3(prop_comps[0].to_float(), prop_comps[1].to_float(), prop_comps[2].to_float())
-						elif prop_default is Color:
-							var prop_comps = prop_string.split(" ")
-							var prop_color = Color()
-							
-							if "." in prop_comps[0] or "." in prop_comps[1] or "." in prop_comps[2]:
-								prop_color.r = prop_comps[0].to_float()
-								prop_color.g = prop_comps[1].to_float()
-								prop_color.b = prop_comps[2].to_float()
+							var prop_comps = prop_string.split_floats(" ")
+							if prop_comps.size() == 3:
+								properties[property] = Vector3(prop_comps[0], prop_comps[1], prop_comps[2])
 							else:
-								prop_color.r8 = prop_comps[0].to_int()
-								prop_color.g8 = prop_comps[1].to_int()
-								prop_color.b8 = prop_comps[2].to_int()
+								push_error("Invalid vector format for \'" + property + "\' in entity \'" + classname + "\': " + prop_string)
+								properties[property] = prop_default
+						elif prop_default is Color:
+							var prop_color = prop_default
+							var prop_comps = prop_string.split(" ")
+							if prop_comps.size() == 3:
+								if "." in prop_comps[0] or "." in prop_comps[1] or "." in prop_comps[2]:
+									prop_color.r = prop_comps[0].to_float()
+									prop_color.g = prop_comps[1].to_float()
+									prop_color.b = prop_comps[2].to_float()
+								else:
+									prop_color.r8 = prop_comps[0].to_int()
+									prop_color.g8 = prop_comps[1].to_int()
+									prop_color.b8 = prop_comps[2].to_int()
+							else:
+								push_error("Invalid color format for \'" + property + "\' in entity \'" + classname + "\': " + prop_string)
 								
 							properties[property] = prop_color
 						elif prop_default is Dictionary:


### PR DESCRIPTION
Got this in a DM:
> Remember saying my point entities (lights) didn't get generated? It was my mistake... partially. Took me while to figure it out. There was one light source with a wrong "mangle" value. It was just 0. It broke the whole entity generation. Basically what happened, it was looking for a vector. I got a "invalid get index '1' on base array" all the time but didn't really get, why. So that's why. It had only 1 element instead of 3 for all axis. It not just doesn't skip the problematic property but breaks the whole entity generation. 
> 
> Found the faulty light, learnt my lesson, but Qodot needs error handling with a user friendly info to tell where is the issue and instead of breaking everything, just skip the property.

Qodot assumes that you are always inputting the appropriate values into your key value pairs and sets the property type based upon the default values set. This doesn't cause problems for Integers, Floats, and Strings, because Strings can convert to them just fine. However, if you input an incorrectly formatted Quake Vector into your key value pair then Qodot currently won't get the correct number of elements for its vector components, causing it to index the array out of bounds.

This PR adds a check to make sure the vectors are the appropriate sizes, and if not use the default property value instead.