### PR TITLE
Mend regression in parsing entity string values containing spaces

### DIFF
--- a/addons/qodot/src/core/qodot_map_parser.gd
+++ b/addons/qodot/src/core/qodot_map_parser.gd
@@ -136,10 +136,10 @@ func token(buf_str: String) -> void:
 				if current_property != "":
 					current_property = ""
 				
-			if is_first or is_last:
-				current_property += buf_str
+			if not is_last:
+				current_property += buf_str + " "
 			else:
-				current_property += " " + buf_str + " "
+				current_property += buf_str
 				
 			if is_last:
 				current_entity.properties[prop_key] = current_property.substr(1, len(current_property) - 2)


### PR DESCRIPTION
I use entity values for things like signs and some interactable button prompts. I noticed after the transition between C# and GDScript that the parser behaviour has changed:

![image](https://github.com/QodotPlugin/Qodot/assets/97406365/d87685ae-0e30-463d-8291-80d2302770a5)

![image](https://github.com/QodotPlugin/Qodot/assets/97406365/e12d8c48-f06c-44d0-803c-0eee200d29aa)

I'm not familiar with the format's grammar and found what I think is the source of the bug by tracing back through the control flow manually. It seems that the parsing rules are subtly different and now strings containing spaces are sometimes parsed incorrectly, with extra spaces added and sometimes spaces being snipped out erroneously.

This PR is a small change to the parsing logic that hopefully fixes the issue.