### PR TITLE
Fix Incorrect Function Call from FetchSurfaces to fetch_surfaces

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -853,7 +853,7 @@ func build_worldspawn_layer_collision_shapes() -> void:
 		
 		qodot.gather_worldspawn_layer_collision_surfaces(0)
 		
-		var layer_surfaces := qodot.FetchSurfaces(inverse_scale_factor) as Array
+		var layer_surfaces := qodot.fetch_surfaces(inverse_scale_factor) as Array
 		
 		var verts := PackedVector3Array()
 		


### PR DESCRIPTION
Fixed typo, function "FetchSurfaces" doesn't exist in core/qodot.gd.

I couldn't reproduce an error from running the worldspawn layers example map, so maybe that line doesn't get executed there.
(I did first get a missing function error there after upgrading to Godot 4.2 and the latest plugin messed up the maps somehow).
