### PR TITLE
Fix: Connect Signal Assumes Node Will Have Properties

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -1242,6 +1242,9 @@ func connect_signals() -> void:
 
 ## Connect a signal on [code]entity_node[/code] to [code]target_node[/code], possibly mediated by the contents of a [code]signal[/code] or [code]receiver[/code] entity
 func connect_signal(entity_node: Node, target_node: Node) -> void:
+	if not 'properties' in target_node:
+		return
+	
 	if target_node.properties['classname'] == 'signal':
 		var signal_name = target_node.properties['signal_name']
 		


### PR DESCRIPTION
Qodot currently assumes that a Node will have a Properties dictionary when it sees some values populated for its corresponding Entity in a map file. Sometimes a `target` key value can get added to an entity through groups where it should not have one. Sometimes an entity is spawned with no scripts in place. This PR fixes it in the `connect_signal` function so that it no longer attempts to access a property that does not exist.
