### PR TITLE
fix: #136 trenchbroom group hierarchy resolution fails

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -566,7 +566,7 @@ func resolve_group_hierarchy() -> void:
 		if '_tb_id' in properties: 
 			parent_entities[node_idx] = node
 	
-	var group_to_entity_map := {}
+	var child_to_parent_map := {}
 	
 	#For each child,...
 	for node_idx in child_entities:
@@ -590,11 +590,11 @@ func resolve_group_hierarchy() -> void:
 				break
 		#if there's a match, pass it on to the child-parent relationship map
 		if parent:
-			group_to_entity_map[node_idx] = parent_idx 
+			child_to_parent_map[node_idx] = parent_idx 
 	
-	for child_idx in group_to_entity_map:
+	for child_idx in child_to_parent_map:
 		var child = entity_nodes[child_idx]
-		var parent_idx = group_to_entity_map[child_idx]
+		var parent_idx = child_to_parent_map[child_idx]
 		var parent = entity_nodes[parent_idx]
 		
 		queue_add_child(parent, child, null, true)

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -567,8 +567,14 @@ func resolve_group_hierarchy() -> void:
 			child_entities[node_idx] = node
 
 		# identify parents
-		if '_tb_id' in properties: 
-			parent_entities[node_idx] = node
+	        if '_tb_id' in properties:
+	            if properties['_tb_name'] != "Unnamed":
+	                if properties['_tb_type'] == "_tb_group":
+	                    node.name = "group_" + str(properties['_tb_id'])
+	                elif properties['_tb_type'] == "_tb_layer":
+	                    node.name = "layer_" + str(properties['_tb_layer_sort_index'])
+	                node.name = node.name + "_" + properties['_tb_name']
+	            parent_entities[node_idx] = node
 	
 	var child_to_parent_map := {}
 	

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -580,13 +580,13 @@ func resolve_group_hierarchy() -> void:
 		var parent_idx = null
 		
 		#...identify its direct parent out of the parent_entities array
-		for maybedaddy in parent_entities:
-			parent_entity = parent_entities[maybedaddy]
-			parent_properties = entity_dicts[maybedaddy]['properties']
+		for possible_parent in parent_entities:
+			parent_entity = parent_entities[possible_parent]
+			parent_properties = entity_dicts[possible_parent]['properties']
 			
 			if parent_properties['_tb_id'] == tb_group:
 				parent = parent_entity
-				parent_idx = maybedaddy
+				parent_idx = possible_parent
 				break
 		#if there's a match, pass it on to the child-parent relationship map
 		if parent:

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -546,14 +546,14 @@ func resolve_group_hierarchy() -> void:
 	var parent_entities := {}
 	var child_entities := {}
 	
-	# Gather all entities which are parents in a group, and all entities which are children in some group
+	# Gather all entities which are children in some group or parents in some group
 	for node_idx in range(0, entity_nodes.size()):
 		var node = entity_nodes[node_idx]
 		var properties = entity_dicts[node_idx]['properties']
 		
 		if not properties: continue
 		
-		if not '_tb_id' in properties and not '_tb_group' in properties:
+		if not ('_tb_id' in properties or '_tb_group' in properties or '_tb_layer' in properties):
 			continue
 		
 		if not 'classname' in properties: continue
@@ -561,8 +561,12 @@ func resolve_group_hierarchy() -> void:
 		
 		if not classname in entity_definitions: continue
 		var entity_definition = entity_definitions[classname]
-		if '_tb_group' in properties:
+
+		# identify children
+		if '_tb_group' in properties or '_tb_layer' in properties: 
 			child_entities[node_idx] = node
+
+		# identify parents
 		if '_tb_id' in properties: 
 			parent_entities[node_idx] = node
 	
@@ -572,8 +576,13 @@ func resolve_group_hierarchy() -> void:
 	for node_idx in child_entities:
 		var node = child_entities[node_idx]
 		var properties = entity_dicts[node_idx]['properties']
-		var tb_group = properties['_tb_group']
-		
+		var tb_group = null
+		if '_tb_group' in properties:
+			tb_group = properties['_tb_group']
+		elif '_tb_layer' in properties:
+			tb_group = properties['_tb_layer']
+		if tb_group == null: continue
+
 		var parent = null
 		var parent_properties = null
 		var parent_entity = null


### PR DESCRIPTION
fix: #136 trenchbroom group hierarchy resolution fails

`qodot_map.gd`
fix and clean up `resolve_group_hierarchy()` function
- `_tb_id` and `_tb_group` properties determine whether an entity is a parent in a group or a child in one. 
- mapping order seemed to have been reversed
- rename variables

Note: correct group resolution depends on a `func_group` resource ~~with a `properties: Dictionary` available~~ This can be achieved by creating a resource with this name and `qodot_fgd_solid_class.gd` script attached, and, if desired, attaching a script extending QodotEntity.

[EDIT—it is not necessary for the func_group to extend QodotEntity or even have a properties dictionary, including for nested groups, but it is necessary for this resource to exist]. 