### PR TITLE
Replace local paths in examples with project-relative ones.

### DIFF
--- a/addons/qodot/example_scenes/0-visuals/0-structural-geometry/0-structural-geometry.tscn
+++ b/addons/qodot/example_scenes/0-visuals/0-structural-geometry/0-structural-geometry.tscn
@@ -174,7 +174,7 @@ Note that because map files are referenced by global filesystem paths, you will 
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")
-map_file = "C:/Users/Embyr/Desktop/qmap-development/addons/qodot/example_scenes/0-visuals/0-structural-geometry/0-structural-geometry.map"
+map_file = "res://addons/qodot/example_scenes/0-visuals/0-structural-geometry/0-structural-geometry.map"
 inverse_scale_factor = 16.0
 entity_fgd = ExtResource("2")
 base_texture_dir = "res://addons/qodot/textures"

--- a/addons/qodot/example_scenes/0-visuals/1-textures/1-textures.tscn
+++ b/addons/qodot/example_scenes/0-visuals/1-textures/1-textures.tscn
@@ -215,7 +215,7 @@ See `res://textures` for the layout used in this project."
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")
-map_file = "C:/Users/Embyr/Desktop/qmap-development/addons/qodot/example_scenes/0-visuals/1-textures/1-textures.map"
+map_file = "res://addons/qodot/example_scenes/0-visuals/1-textures/1-textures.map"
 inverse_scale_factor = 16.0
 entity_fgd = ExtResource("2")
 base_texture_dir = "res://addons/qodot/textures"

--- a/addons/qodot/example_scenes/0-visuals/2-materials/2-materials.tscn
+++ b/addons/qodot/example_scenes/0-visuals/2-materials/2-materials.tscn
@@ -235,7 +235,7 @@ Materials can also be loaded without a texture of the same name as a sibling fil
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")
-map_file = "C:/Users/Embyr/Desktop/qmap-development/addons/qodot/example_scenes/0-visuals/2-materials/2-materials.map"
+map_file = "res://addons/qodot/example_scenes/0-visuals/2-materials/2-materials.map"
 inverse_scale_factor = 16.0
 entity_fgd = ExtResource("2")
 base_texture_dir = "res://addons/qodot/textures"

--- a/addons/qodot/example_scenes/0-visuals/3-auto-pbr/3-auto-pbr.tscn
+++ b/addons/qodot/example_scenes/0-visuals/3-auto-pbr/3-auto-pbr.tscn
@@ -78,7 +78,7 @@ These can be modified in the `Qodot/Textures` category of the Project Settings w
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")
-map_file = "C:/Users/Embyr/Desktop/qmap-development/addons/qodot/example_scenes/0-visuals/3-auto-pbr/3-auto-pbr.map"
+map_file = "res://addons/qodot/example_scenes/0-visuals/3-auto-pbr/3-auto-pbr.map"
 inverse_scale_factor = 16.0
 entity_fgd = ExtResource("2")
 base_texture_dir = "res://addons/qodot/textures"

--- a/addons/qodot/example_scenes/0-visuals/4-special-textures/4-special-textures.tscn
+++ b/addons/qodot/example_scenes/0-visuals/4-special-textures/4-special-textures.tscn
@@ -122,7 +122,7 @@ When textured with SKIP, a face will omit its visuals from the build. This can b
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")
-map_file = "C:/Users/Embyr/Desktop/qmap-development/addons/qodot/example_scenes/0-visuals/4-special-textures/4-special-textures.map"
+map_file = "res://addons/qodot/example_scenes/0-visuals/4-special-textures/4-special-textures.map"
 inverse_scale_factor = 16.0
 entity_fgd = ExtResource("2")
 base_texture_dir = "res://addons/qodot/textures"

--- a/addons/qodot/example_scenes/1-interactivity/0-point-entities/0-point-entities.tscn
+++ b/addons/qodot/example_scenes/1-interactivity/0-point-entities/0-point-entities.tscn
@@ -128,7 +128,7 @@ transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, -40, 1
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")
-map_file = "C:/Users/Embyr/Desktop/qmap-development/addons/qodot/example_scenes/1-interactivity/0-point-entities/0-point-entities.map"
+map_file = "res://addons/qodot/example_scenes/1-interactivity/0-point-entities/0-point-entities.map"
 inverse_scale_factor = 16.0
 entity_fgd = ExtResource("2")
 base_texture_dir = "res://addons/qodot/textures"

--- a/addons/qodot/example_scenes/1-interactivity/1-brush-entities/1-brush-entities.tscn
+++ b/addons/qodot/example_scenes/1-interactivity/1-brush-entities/1-brush-entities.tscn
@@ -255,7 +255,7 @@ transform = Transform3D(0.642788, 0, -0.766044, 0, 1, 0, 0.766044, 0, 0.642788, 
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")
-map_file = "C:/Users/Embyr/Repos/Qodot/addons/qodot/example_scenes/1-interactivity/1-brush-entities/1-brush-entities.map"
+map_file = "res://addons/qodot/example_scenes/1-interactivity/1-brush-entities/1-brush-entities.map"
 inverse_scale_factor = 16.0
 entity_fgd = ExtResource("2")
 base_texture_dir = "res://addons/qodot/textures"

--- a/addons/qodot/example_scenes/1-interactivity/2-worldspawn-layers/2-worldspawn-layers.tscn
+++ b/addons/qodot/example_scenes/1-interactivity/2-worldspawn-layers/2-worldspawn-layers.tscn
@@ -204,7 +204,7 @@ far = 200.0
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")
-map_file = "C:/Users/Embyr/Repos/Qodot/addons/qodot/example_scenes/1-interactivity/2-worldspawn-layers/2-worldspawn-layers.map"
+map_file = "res://addons/qodot/example_scenes/1-interactivity/2-worldspawn-layers/2-worldspawn-layers.map"
 inverse_scale_factor = 16.0
 entity_fgd = ExtResource("2")
 base_texture_dir = "res://addons/qodot/textures"

--- a/addons/qodot/example_scenes/1-interactivity/3-basic-signal-wiring/3-basic-signal-wiring.tscn
+++ b/addons/qodot/example_scenes/1-interactivity/3-basic-signal-wiring/3-basic-signal-wiring.tscn
@@ -297,7 +297,7 @@ far = 200.0
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")
-map_file = "C:/Users/Embyr/Desktop/qmap-development/addons/qodot/example_scenes/1-interactivity/3-basic-signal-wiring/3-basic-signal-wiring.map"
+map_file = "res://addons/qodot/example_scenes/1-interactivity/3-basic-signal-wiring/3-basic-signal-wiring.map"
 inverse_scale_factor = 16.0
 entity_fgd = ExtResource("2")
 base_texture_dir = "res://addons/qodot/textures"

--- a/addons/qodot/example_scenes/1-interactivity/4-advanced-signal-wiring/4-advanced-signal-wiring.tscn
+++ b/addons/qodot/example_scenes/1-interactivity/4-advanced-signal-wiring/4-advanced-signal-wiring.tscn
@@ -191,7 +191,7 @@ far = 200.0
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")
-map_file = "C:/Users/Embyr/Desktop/qmap-development/addons/qodot/example_scenes/1-interactivity/4-advanced-signal-wiring/4-advanced-signal-wiring.map"
+map_file = "res://addons/qodot/example_scenes/1-interactivity/4-advanced-signal-wiring/4-advanced-signal-wiring.map"
 inverse_scale_factor = 16.0
 entity_fgd = ExtResource("2")
 base_texture_dir = "res://addons/qodot/textures"

--- a/addons/qodot/example_scenes/2-miscallaneous/0-trenchbroom-group-hierarchy/0-trenchbroom-group-hierarchy.tscn
+++ b/addons/qodot/example_scenes/2-miscallaneous/0-trenchbroom-group-hierarchy/0-trenchbroom-group-hierarchy.tscn
@@ -123,7 +123,7 @@ omni_range = 40.0
 
 [node name="QodotMap" type="Node3D" parent="."]
 script = ExtResource("1")
-map_file = "C:/Users/Embyr/Desktop/qmap-development/addons/qodot/example_scenes/2-miscallaneous/0-trenchbroom-group-hierarchy/0-trenchbroom-group-hierarchy.map"
+map_file = "res://addons/qodot/example_scenes/2-miscallaneous/0-trenchbroom-group-hierarchy/0-trenchbroom-group-hierarchy.map"
 inverse_scale_factor = 16.0
 entity_fgd = ExtResource("2")
 base_texture_dir = "res://addons/qodot/textures"


### PR DESCRIPTION
  1. What it changes: Replace local paths in examples with project-relative ones.
  2. Why it's needed: If you want to (re-)build the examples yourself, the paths wont work

Pretty straightforward, I just stumbled over this and saw that the examples has local paths.