### PR TITLE
Fix qodot_plugin removing the wrong custom type when _exit_tree is called

### DIFF
--- a/addons/qodot/src/qodot_plugin.gd
+++ b/addons/qodot/src/qodot_plugin.gd
@@ -55,7 +55,7 @@ func _enter_tree() -> void:
 func _exit_tree() -> void:
 	remove_custom_type("QodotMap")
 	remove_custom_type("QodotEntity")
-	remove_custom_type("QodotSpatial")
+	remove_custom_type("QodotNode3D")
 	remove_import_plugin(map_import_plugin)
 	remove_import_plugin(palette_import_plugin)
 	if wad_import_plugin:


### PR DESCRIPTION
Thanks for contributing! Help us understand your pull request by explaining:
  1. What it changes
  Instead of removing custom type "QodotSpatial" (which is a custom type that doesn't even exist), it removes "QodotNode3D" in the qodot_plugin.gd _exit_tree method.
  3. Why it's needed
  The editor would throw the error "Could not find base class QodotNode3D". When disabling the plugin, Qodot wouldn't remove QodotNode3D from it's custom types, and then when the plugin is enabled again, the project would essentially have 2 classes of the name QodotNode3D, thus confusing the editor.
### Does this pull request address an existing issue?
No.