### PR TITLE
Add albedo support for auto pbr materials

### DIFF
--- a/addons/qodot/game_definitions/trenchbroom_game_config.tres
+++ b/addons/qodot/game_definitions/trenchbroom_game_config.tres
@@ -26,7 +26,7 @@ map_formats = Array[Dictionary]([{
 }, {
 "format": "Quake3"
 }])
-texture_exclusion_patterns = Array[String](["*_ao", "*_emission", "*_heightmap", "*_metallic", "*_normal", "*_orm", "*_roughness", "*_sss"])
+texture_exclusion_patterns = Array[String](["*_ao", "*_emission", "*_heightmap", "*_metallic", "*_normal", "*_orm", "*_roughness", "*_sss", "*_albedo"])
 fgd_files = Array[Resource]([ExtResource("5_lbrmn")])
 entity_scale = "1"
 default_uv_scale = Vector2(1, 1)

--- a/addons/qodot/src/qodot_plugin.gd
+++ b/addons/qodot/src/qodot_plugin.gd
@@ -83,6 +83,7 @@ func setup_project_settings() -> void:
 	try_add_project_setting('qodot/textures/emission_pattern', TYPE_STRING, QodotTextureLoader.PBR_SUFFIX_PATTERNS[QodotTextureLoader.PBRSuffix.EMISSION])
 	try_add_project_setting('qodot/textures/ao_pattern', TYPE_STRING, QodotTextureLoader.PBR_SUFFIX_PATTERNS[QodotTextureLoader.PBRSuffix.AO])
 	try_add_project_setting('qodot/textures/height_pattern', TYPE_STRING, QodotTextureLoader.PBR_SUFFIX_PATTERNS[QodotTextureLoader.PBRSuffix.HEIGHT])
+	try_add_project_setting('qodot/textures/albedo_pattern', TYPE_STRING, QodotTextureLoader.PBR_SUFFIX_PATTERNS[QodotTextureLoader.PBRSuffix.ALBEDO])
 
 ## Add property, if not already present. See [method add_project_setting] for usage.
 func try_add_project_setting(name: String, type: int, value, info: Dictionary = {}) -> void:

--- a/addons/qodot/src/resources/game-definitions/trenchbroom_game_config.gd
+++ b/addons/qodot/src/resources/game-definitions/trenchbroom_game_config.gd
@@ -32,7 +32,7 @@ extends Resource
 ]
 
 ## Textures matching these patterns will be hidden from Trenchbroom.
-@export var texture_exclusion_patterns: Array[String] = ["*_ao", "*_emission", "*_heightmap", "*_metallic", "*_normal", "*_orm", "*_roughness", "*_sss"]
+@export var texture_exclusion_patterns: Array[String] = ["*_ao", "*_emission", "*_heightmap", "*_metallic", "*_normal", "*_orm", "*_roughness", "*_sss", "*_albedo"]
 
 ## Array of FGD resources to include with this game.
 @export var fgd_files : Array[Resource] = [

--- a/addons/qodot/src/util/qodot_texture_loader.gd
+++ b/addons/qodot/src/util/qodot_texture_loader.gd
@@ -106,7 +106,7 @@ func load_texture(texture_name: String) -> Texture2D:
 		var texture_path := "%s/%s.%s" % [base_texture_path, texture_name, texture_extension]
 		if ResourceLoader.exists(texture_path, "Texture2D"):
 			return load(texture_path) as Texture2D
-		
+
 	var texture_name_lower : String = texture_name.to_lower()
 	for texture_wad in texture_wad_resources:
 		if texture_name_lower in texture_wad.textures:
@@ -206,8 +206,8 @@ func get_pbr_texture(texture: String, suffix: PBRSuffix) -> Texture2D:
 				texture_extension
 			]
 		]
-		
+
 		if(FileAccess.file_exists(path)):
-						return load(path) as Texture2D
+			return load(path) as Texture2D
 
 	return null

--- a/addons/qodot/src/util/qodot_texture_loader.gd
+++ b/addons/qodot/src/util/qodot_texture_loader.gd
@@ -9,6 +9,7 @@ enum PBRSuffix {
 	EMISSION,
 	AO,
 	HEIGHT,
+	ALBEDO
 }
 
 # Suffix string / Godot enum / StandardMaterial3D property
@@ -19,6 +20,7 @@ const PBR_SUFFIX_NAMES := {
 	PBRSuffix.EMISSION: 'emission',
 	PBRSuffix.AO: 'ao',
 	PBRSuffix.HEIGHT: 'height',
+	PBRSuffix.ALBEDO: 'albedo',
 }
 
 const PBR_SUFFIX_PATTERNS := {
@@ -27,7 +29,8 @@ const PBR_SUFFIX_PATTERNS := {
 	PBRSuffix.ROUGHNESS: '%s_roughness.%s',
 	PBRSuffix.EMISSION: '%s_emission.%s',
 	PBRSuffix.AO: '%s_ao.%s',
-	PBRSuffix.HEIGHT: '%s_height.%s'
+	PBRSuffix.HEIGHT: '%s_height.%s',
+	PBRSuffix.ALBEDO: '%s_albedo.%s'
 }
 
 var PBR_SUFFIX_TEXTURES := {
@@ -36,7 +39,8 @@ var PBR_SUFFIX_TEXTURES := {
 	PBRSuffix.ROUGHNESS: StandardMaterial3D.TEXTURE_ROUGHNESS,
 	PBRSuffix.EMISSION: StandardMaterial3D.TEXTURE_EMISSION,
 	PBRSuffix.AO: StandardMaterial3D.TEXTURE_AMBIENT_OCCLUSION,
-	PBRSuffix.HEIGHT: StandardMaterial3D.TEXTURE_HEIGHTMAP
+	PBRSuffix.HEIGHT: StandardMaterial3D.TEXTURE_HEIGHTMAP,
+	PBRSuffix.ALBEDO: StandardMaterial3D.TEXTURE_ALBEDO
 }
 
 const PBR_SUFFIX_PROPERTIES := {
@@ -102,7 +106,7 @@ func load_texture(texture_name: String) -> Texture2D:
 		var texture_path := "%s/%s.%s" % [base_texture_path, texture_name, texture_extension]
 		if ResourceLoader.exists(texture_path, "Texture2D"):
 			return load(texture_path) as Texture2D
-
+		
 	var texture_name_lower : String = texture_name.to_lower()
 	for texture_wad in texture_wad_resources:
 		if texture_name_lower in texture_wad.textures:
@@ -202,8 +206,8 @@ func get_pbr_texture(texture: String, suffix: PBRSuffix) -> Texture2D:
 				texture_extension
 			]
 		]
-
+		
 		if(FileAccess.file_exists(path)):
-			return load(path) as Texture2D
+						return load(path) as Texture2D
 
 	return null


### PR DESCRIPTION
This adds albedo map support for auto-pbr materials. By default if you have a map e.g. `textures/my_material/my_material_albedo.png` it will be used instead of the previous `textures/my_material.png`. The later will still be needed and will be used by Trenchbroom. This way it is possible to use different textures (e.g. scaled versions) for Trenchbroom and Godot.
If you don't add a albedo map, the behaviour will be the same as before

Before
<img width="977" alt="image" src="https://github.com/QodotPlugin/Qodot/assets/6848069/3c7824a8-b3dc-457f-a147-12fac40fabe5">

After
<img width="968" alt="image" src="https://github.com/QodotPlugin/Qodot/assets/6848069/08d03548-3ce9-4d6d-bfed-55a41a9bae6c">

This implements #150 