### PR TITLE
replaces build bool with buttons

### DIFF
--- a/addons/qodot/src/qodot_plugin.gd
+++ b/addons/qodot/src/qodot_plugin.gd
@@ -10,6 +10,8 @@ var qodot_map_control: Control = null
 var qodot_map_progress_bar: Control = null
 var edited_object_ref: WeakRef = weakref(null)
 
+var qodot_editor_button = preload("./util/qodot_editor_button.gd").new()
+
 func _get_plugin_name() -> String:
 	return "Qodot"
 
@@ -52,6 +54,8 @@ func _enter_tree() -> void:
 	add_custom_type("QodotEntity", "Node3D", preload("res://addons/qodot/src/nodes/qodot_entity.gd"), null)
 	add_custom_type("QodotNode3D", "Node3D", preload("res://addons/qodot/src/nodes/qodot_node3d.gd"), null)
 
+	add_inspector_plugin(qodot_editor_button)
+
 func _exit_tree() -> void:
 	remove_custom_type("QodotMap")
 	remove_custom_type("QodotEntity")
@@ -74,6 +78,8 @@ func _exit_tree() -> void:
 		remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_BOTTOM, qodot_map_progress_bar)
 		qodot_map_progress_bar.queue_free()
 		qodot_map_progress_bar = null
+	
+	remove_inspector_plugin(qodot_editor_button)
 
 ## Add Qodot-specific settings to Godot's Project Settings
 func setup_project_settings() -> void:

--- a/addons/qodot/src/util/qodot_editor_button.gd
+++ b/addons/qodot/src/util/qodot_editor_button.gd
@@ -1,0 +1,43 @@
+extends EditorInspectorPlugin
+class_name QodotEditorButton
+
+func _can_handle(object):
+	if object is TrenchBroomGameConfig:
+		return true
+	if object is QodotFGDFile:
+		return true
+	if object is QodotProjectConfig:
+		return true
+	return false
+
+func _parse_property(object, type, name, hint_type, hint_string, usage_flags, wide):
+	if object is QodotFGDFile or object is TrenchBroomGameConfig:
+		if name == "export_file":
+			create_button("name","Click to export",name)
+			return true
+	elif object is QodotProjectConfig:
+		if name == "export_qodot_settings":
+			create_button("name","Click to export settings",name)
+			return true
+	return false
+
+func create_button(name:StringName,text:StringName,property:StringName):
+	var b = ButtonTrigger.new()
+	b.text = text
+	b.property = property
+	add_property_editor(name,b)
+
+class ButtonTrigger:
+	extends EditorProperty
+	var button = Button.new()
+	var text = "Trigger Export"
+	var property = "ERROR"
+	func _ready():
+		add_child(button)
+		add_focusable(button)
+		button.text = text
+		button.pressed.connect(trigger)
+	func trigger():
+		emit_changed(property,true,"",true)
+
+


### PR DESCRIPTION
Thanks for contributing! Help us understand your pull request by explaining:
  1. What it changes
This replaces the bool build button with a button to trigger builds. 
 
  3. Why it's needed
Just makes it clearer what it does from the inspector

This will not be necessary after 4.3, if/when [iFire's `@tool_button` gets merged](https://github.com/godotengine/godot/pull/78355).